### PR TITLE
Update GitHub URLs for the new organisation

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ See [About This Site](content/about-this-site/_index.md) for more information
   - `start`: Builds and serves the site at http://localhost:1313 with Hugo.
   - `test:a11y`: Builds and serves the site, then uses Playwright and axe to test accessibility
   - `test:a11y:tests`: Not meant for independent use, only as part of `test:a11y`
-  - `test:spelling`: Reports all apparent spelling errors. WIP, ref [#83](https://github.com/minetest/dev.luanti.org/issues/83) for details.
+  - `test:spelling`: Reports all apparent spelling errors. WIP, ref [#83](https://github.com/luanti-org/dev.luanti.org/issues/83) for details.
 - depdendencies
   - `hugo-extended`: Static site generator that turns Markdown and shortcodes into HTML
 - devDependencies

--- a/content/_index.md
+++ b/content/_index.md
@@ -17,13 +17,13 @@ Contribute to Luanti!
 ---------------------
 
 #### Develop the core engine
-* Browse the [source code](https://github.com/minetest/minetest)
+* Browse the [source code](https://github.com/luanti-org/luanti)
 * [Engine overview](/Engine)
 * Help [make a release](/Releasing_Luanti)
 
 #### Develop a mod or a game
 * Get [introduced to the mod API](/Modding_Intro)
-* Check out the [Lua API Documentation](https://github.com/minetest/minetest/blob/master/doc/lua_api.md)
+* Check out the [Lua API Documentation](https://github.com/luanti-org/luanti/blob/master/doc/lua_api.md)
 
 #### Document, translate, and create
 * Help with the [engine documentation](/Engine)

--- a/content/about-this-site/_index.md
+++ b/content/about-this-site/_index.md
@@ -6,7 +6,7 @@ bookCollapseSection: true
 # About This Site
 
 This site is created using [Hugo](https://gohugo.io/), with theme [Hugo Book](https://themes.gohugo.io/themes/hugo-book/). 
-The site's source content can be found [on GitHub](https://github.com/minetest/dev.luanti.org/tree/master/content).
+The site's source content can be found [on GitHub](https://github.com/luanti-org/dev.luanti.org/tree/master/content).
 
 ## Contributing
 
@@ -23,4 +23,4 @@ Luanti Documentation will be the central resource for the Luanti project as a wh
 * Engine reference and internal structures
 * Server and platform (player-facing) usage and guides
 
-Our roadmap can be found at [GitHub issue #113: Roadmap](https://github.com/minetest/dev.luanti.org/issues/113).
+Our roadmap can be found at [GitHub issue #113: Roadmap](https://github.com/luanti-org/dev.luanti.org/issues/113).

--- a/content/about-this-site/local-development.md
+++ b/content/about-this-site/local-development.md
@@ -9,7 +9,7 @@ _(anyone)_
 When cloning the repository you need to clone it recursively so that the theme submodule gets included:
 
 ```bash
-git clone --recursive https://github.com/minetest/dev.luanti.org
+git clone --recursive https://github.com/luanti-org/dev.luanti.org
 ```
 
 If you have already cloned you can fetch the submodules as such:

--- a/content/changelog.md
+++ b/content/changelog.md
@@ -146,7 +146,7 @@ Released 2024-08-11
 
 ### Deprecations and compatibility notes
 
-* "mod\_translation\_updater.py" is now located at [https://github.com/minetest/modtools](https://github.com/minetest/modtools) (_Zughy_)
+* "mod\_translation\_updater.py" is now located at [https://github.com/luanti-org/modtools](https://github.com/luanti-org/modtools) (_Zughy_)
 * The setting "opaque\_water" is now called "translucent\_liquids". (_Xeno333_)
 * Disabling fog and camera updates now requires the "debug" privilege (_sfan5_)
 * Since 5.9.0-dev, the Minetest repository now includes IrrlichtMt. The minetest/irrlicht repository is no longer a dependency of newer releases.

--- a/content/changelog.md
+++ b/content/changelog.md
@@ -5,7 +5,7 @@ aliases:
 ---
 
 # Changelog
-Note that not all changes made to the code between releases are listed here. Fixes to bugs that were introduced after the previous release, small internal changes, code style fixes, and changes of the like are not listed. If you want a list of _every_ change made between releases see the [commit log](https://github.com/minetest/minetest/commits/master).
+Note that not all changes made to the code between releases are listed here. Fixes to bugs that were introduced after the previous release, small internal changes, code style fixes, and changes of the like are not listed. If you want a list of _every_ change made between releases see the [commit log](https://github.com/luanti-org/luanti/commits/master).
 
 5.9.1 → 5.10.0
 --------------
@@ -256,7 +256,7 @@ As part of Minetest's efforts to modernise and improve graphics code, we've been
 
 ### Minetest Game
 
-* No longer bundled in Minetest. Please have look at [https://github.com/minetest/minetest\_game/](https://github.com/minetest/minetest_game/)
+* No longer bundled in Minetest. Please have look at [https://github.com/luanti-org/luanti\_game/](https://github.com/luanti-org/luanti_game/)
 
 5.7.0 → 5.8.0
 -------------
@@ -349,7 +349,7 @@ Released on 4 December 2023.
 ### Minetest Game
 
 * **Minetest Game is no longer the default game and no longer installed by default**
-* New water textures (the old ones were [non-free](https://github.com/minetest/minetest_game/issues/3051)) (_Lopano_)
+* New water textures (the old ones were [non-free](https://github.com/luanti-org/luanti_game/issues/3051)) (_Lopano_)
 * Improve leaves textures in "Opaque Leaves" mode (_Wuzzy_)
 * When a player dies in protected air, bones now spawn as a block instead of dropping as an item (_OgelGames_)
 * Add API for sapling growth (_aegroto_)
@@ -369,13 +369,13 @@ Released on 8 April 2023
 ### Deprecations and compatibility notes
 
 * The default key for pitchmove was removed. Specify a key manually to use this feature.
-    * See [https://github.com/minetest/minetest/pull/13319](https://github.com/minetest/minetest/pull/13319) for details
+    * See [https://github.com/luanti-org/luanti/pull/13319](https://github.com/luanti-org/luanti/pull/13319) for details
 * Special handling of `${key}` syntax in metadata values are deprecated
-    * See [https://github.com/minetest/minetest/pull/12970](https://github.com/minetest/minetest/pull/12970) for details
+    * See [https://github.com/luanti-org/luanti/pull/12970](https://github.com/luanti-org/luanti/pull/12970) for details
 * Worlds with unresolved dependencies can no longer be loaded. This ensures that the specified mods are loaded properly.
-    * See [https://github.com/minetest/minetest/pull/12542](https://github.com/minetest/minetest/pull/12542) for details
+    * See [https://github.com/luanti-org/luanti/pull/12542](https://github.com/luanti-org/luanti/pull/12542) for details
 * The default key for (un)limited range was removed. Specify a key manually to use this feature.
-    * See [https://github.com/minetest/minetest/pull/12632](https://github.com/minetest/minetest/pull/12632) for details
+    * See [https://github.com/luanti-org/luanti/pull/12632](https://github.com/luanti-org/luanti/pull/12632) for details
 * Development Test is no longer being distributed in official Minetest releases
     * This was never meant for players to begin with, this “game” is exclusively meant for engine development
     * To get it back, build Minetest from source code (recommended) or download Development Test from [ContentDB](https://content.luanti.org/packages/Minetest/devtest/)
@@ -1481,7 +1481,7 @@ This was chosen for a few reasons:
 * Allows us to release patch/bug fix only releases without adding a silly 4th number
 * Doesn't imply that this version is the first stable/finished version as much as a 1.0.0 does.
 
-For some context, read [the issue that resulted in this change](https://github.com/minetest/minetest/issues/6073).
+For some context, read [the issue that resulted in this change](https://github.com/luanti-org/luanti/issues/6073).
 
 ### Breaking changes and deprecations
 

--- a/content/changelog.md
+++ b/content/changelog.md
@@ -256,7 +256,7 @@ As part of Minetest's efforts to modernise and improve graphics code, we've been
 
 ### Minetest Game
 
-* No longer bundled in Minetest. Please have look at [https://github.com/luanti-org/luanti\_game/](https://github.com/luanti-org/luanti_game/)
+* No longer bundled in Minetest. Please have look at [https://github.com/luanti-org/minetest_game/](https://github.com/luanti-org/minetest_game/)
 
 5.7.0 → 5.8.0
 -------------
@@ -349,7 +349,7 @@ Released on 4 December 2023.
 ### Minetest Game
 
 * **Minetest Game is no longer the default game and no longer installed by default**
-* New water textures (the old ones were [non-free](https://github.com/luanti-org/luanti_game/issues/3051)) (_Lopano_)
+* New water textures (the old ones were [non-free](https://github.com/luanti-org/minetest_game/issues/3051)) (_Lopano_)
 * Improve leaves textures in "Opaque Leaves" mode (_Wuzzy_)
 * When a player dies in protected air, bones now spawn as a block instead of dropping as an item (_OgelGames_)
 * Add API for sapling growth (_aegroto_)

--- a/content/compiling-a-headless-linux-server.md
+++ b/content/compiling-a-headless-linux-server.md
@@ -54,7 +54,7 @@ make amalg
 Clone Luanti with Git. `-b stable-5` will checkout the latest stable version to build, which may be recommended to run a server for stability reasons over the latest development version. Omitting this will clone the latest development version instead.
 
 ```bash
-git clone -b stable-5 --depth 1 https://github.com/minetest/minetest.git
+git clone -b stable-5 --depth 1 https://github.com/luanti-org/luanti.git
 cd minetest
 ```
 

--- a/content/compiling-on-windows-using-msys2.md
+++ b/content/compiling-on-windows-using-msys2.md
@@ -34,7 +34,7 @@ cd /c/Users/$USER/Desktop
 Clone Luanti:
 
 ```bash
-git clone --depth 1 https://github.com/minetest/minetest
+git clone --depth 1 https://github.com/luanti-org/luanti
 cd minetest
 ```
 

--- a/content/creating-texture-packs.md
+++ b/content/creating-texture-packs.md
@@ -213,7 +213,7 @@ Hopefully if your using Linux you'll know how to do something similar, or someon
 
 ### Special Textures
 
-Luanti has some "special" textures which can be provided by texture packs to retexture engine-provided or special textures. See [texture\_packs.txt](https://github.com/minetest/minetest/blob/master/doc/texture_packs.txt) in the Luanti source tree contains a list of all these special textures
+Luanti has some "special" textures which can be provided by texture packs to retexture engine-provided or special textures. See [texture\_packs.txt](https://github.com/luanti-org/luanti/blob/master/doc/texture_packs.txt) in the Luanti source tree contains a list of all these special textures
 
 Editing or Creating Textures
 ----------------------------
@@ -239,7 +239,7 @@ Textures for Luanti maybe any size, but square images whose size is a power of 2
 
 Generally Luanti games and mods use the `.png` image format, but `.jpg`, `.bmp` `.tga` are also supported and may exist in some mods.
 
-Also check out the \[[texture\_packs.txt](http://github.com/minetest/minetest/blob/master/doc/texture_packs.txt)\] documentation in the Luanti source tree.
+Also check out the \[[texture\_packs.txt](http://github.com/luanti-org/luanti/blob/master/doc/texture_packs.txt)\] documentation in the Luanti source tree.
 
 #### Where to Start
 

--- a/content/database-backends.md
+++ b/content/database-backends.md
@@ -96,7 +96,7 @@ Redis is an in-memory key-value datastore that can be used both as a cache and f
 As of March 2024 Redis switched to a non-free license for future versions. Forks of the final free Redis version, such as [Redict](https://redict.io) and [Valkey](https://valkey.io), may serve as a compatible drop-in replacement for Luanti's Redis support.
 
 {{< notice note >}}
-The use of Redis was deprecated in 5.9.0 and was set to be removed in 5.10, but is no longer deprecated (see [Luanti issue #14822](https://github.com/minetest/minetest/issues/14822)).
+The use of Redis was deprecated in 5.9.0 and was set to be removed in 5.10, but is no longer deprecated (see [Luanti issue #14822](https://github.com/luanti-org/luanti/issues/14822)).
 {{< /notice >}}
 
 #### Extra world.mt settings for Redis
@@ -126,7 +126,7 @@ host=<db_host> user=<db_user> password=<db_password> dbname=<db_name>
 
 ### MariaDB (WIP)
 
-A WIP MariaDB database backend was implemented in [#13266](https://github.com/minetest/minetest/pull/13266), but was abandoned before it could be merged. The addition of a MariaDB backend is approved by the core developers and the pull request may be adopted by someone who is interested in it being available in upstream.
+A WIP MariaDB database backend was implemented in [#13266](https://github.com/luanti-org/luanti/pull/13266), but was abandoned before it could be merged. The addition of a MariaDB backend is approved by the core developers and the pull request may be adopted by someone who is interested in it being available in upstream.
 
 MariaDB allows about the same capabilities as PostgreSQL and has the same qualities as it, running as a separate database server.
 

--- a/content/development-tools.md
+++ b/content/development-tools.md
@@ -11,7 +11,7 @@ In addition to this list, you can also see the [Development Tools](https://conte
 
 ## Engine development
 - [Development Test](https://wiki.luanti.org/Games/Development_Test): A testing game for testing various engine features
-- [/minetest/util](https://github.com/minetest/minetest/tree/master/util): Various maintenance utilities
+- [/minetest/util](https://github.com/luanti-org/luanti/tree/master/util): Various maintenance utilities
 
 ## General Lua Tools
 - [luacheck](https://github.com/lunarmodules/luacheck): Lua linter and static code analyser (see also [the chapter in rubenwardy's modding book](https://rubenwardy.com/minetest_modding_book/en/quality/luacheck.html))

--- a/content/development-tools.md
+++ b/content/development-tools.md
@@ -7,7 +7,7 @@ aliases:
 # Development Tools
 This page contains a list of tools that are useful for developing games and mods for Luanti, or working with parts of the engine.
 
-In addition to this list, you can also see the [Development Tools](https://content.luanti.org/packages/?tag=developer_tools) tag on ContentDB for mods useful for development and the [modtools](https://github.com/minetest/modtools) repository for officially maintained modding tools.
+In addition to this list, you can also see the [Development Tools](https://content.luanti.org/packages/?tag=developer_tools) tag on ContentDB for mods useful for development and the [modtools](https://github.com/luanti-org/modtools) repository for officially maintained modding tools.
 
 ## Engine development
 - [Development Test](https://wiki.luanti.org/Games/Development_Test): A testing game for testing various engine features
@@ -50,7 +50,7 @@ In addition to this list, you can also see the [Development Tools](https://conte
 
 ## Translation
 - [Gettext utils](https://www.gnu.org/software/gettext/): For maintaining content translations for the new .po/Gettext format
-- [mod_translation_updater](https://github.com/minetest/modtools/blob/main/mod_translation_updater.py): Python script to create and update legacy .tr mod translation files
+- [mod_translation_updater](https://github.com/luanti-org/modtools/blob/main/mod_translation_updater.py): Python script to create and update legacy .tr mod translation files
 
 ## ContentDB
 - [cdbrelease](https://gitlab.com/sztest/cdbrelease): Release automation tool for ContentDB packages

--- a/content/docs/classes/metadata.md
+++ b/content/docs/classes/metadata.md
@@ -23,7 +23,7 @@ No type information is stored for values; values will be coerced to and from str
 {{< /notice >}}
 
 {{< notice warning >}}
-[Getters currently resolve the value `${key}` to the value associated with `key`](https://github.com/minetest/minetest/issues/12577).
+[Getters currently resolve the value `${key}` to the value associated with `key`](https://github.com/luanti-org/luanti/issues/12577).
 {{< /notice >}}
 
 {{< notice tip >}}

--- a/content/docs/classes/playermetadata.md
+++ b/content/docs/classes/playermetadata.md
@@ -23,7 +23,7 @@ Used to obtain a mutable PlayerMetaData reference.
 Luanti requiring a valid `player` object means PlayerMetaData is only accessible while players are online; if you need per-player storage while players are offline, you can use ModStorage and save either a serialized table per-player or concatenate the keys of the per-player entries with the playername using a delimiter. Reusing the above example, `fancy_quests:score` might be stored as `<playername>:score` or as key-value pair with key `<playername>` and value `core.write_json{score = ...}` (or `core.serialize`)  in ModStorage.
 {{< /notice >}}
 
-A [feature request](https://github.com/minetest/minetest/issues/6193) to make PlayerMetaData available for offline players exists;
+A [feature request](https://github.com/luanti-org/luanti/issues/6193) to make PlayerMetaData available for offline players exists;
 
 **Returns:**
 - `meta` - PlayerMetaData: Public & shared PlayerMetaData object for the player

--- a/content/docs/classes/raycast.md
+++ b/content/docs/classes/raycast.md
@@ -53,7 +53,7 @@ You may use this to determine e.g. whether a target would be visible to a mob. R
 Creates a raycast object; OOP-constructor-style alias for `core.raycast`.
 
 {{< notice info >}}
-[Raycasts work on selection-, not collision boxes, making them coherent with player pointing but not physics (collisions) unless selection- and collision boxes are identical.](https://github.com/minetest/minetest/issues/12673)
+[Raycasts work on selection-, not collision boxes, making them coherent with player pointing but not physics (collisions) unless selection- and collision boxes are identical.](https://github.com/luanti-org/luanti/issues/12673)
 {{< /notice >}}
 
 {{< notice tip >}}
@@ -61,7 +61,7 @@ Have selection boxes, collision boxes (and ideally even visuals) match for all n
 {{< /notice >}}
 
 {{< notice info >}}
-[Serverside raycasts do not support attachments properly; the server is unaware of model specificities, doesn't keep track of automatic rotation etc.](https://github.com/minetest/minetest/issues/10304)
+[Serverside raycasts do not support attachments properly; the server is unaware of model specificities, doesn't keep track of automatic rotation etc.](https://github.com/luanti-org/luanti/issues/10304)
 {{< /notice >}}
 
 **Arguments:**

--- a/content/docs/classes/vector.md
+++ b/content/docs/classes/vector.md
@@ -11,7 +11,7 @@ Unless otherwise noted, the `vector` type always refers to the metatable-enhance
 Do note that functions here will accept an old-style (non-metatable) `vector`, but you cannot perform metatable operations with said `vector`.
 
 {{< notice tip >}}
-The respective source code is located [here](https://github.com/minetest/minetest/blob/master/builtin/common/vector.lua).
+The respective source code is located [here](https://github.com/luanti-org/luanti/blob/master/builtin/common/vector.lua).
 {{< /notice >}}
 
 ## `vector` Namespace

--- a/content/docs/object-properties.md
+++ b/content/docs/object-properties.md
@@ -57,7 +57,7 @@ Controls whether the object collides with other objects.
 {{< /notice >}}
 
 {{< notice note >}}
-This works with players as well but you may experience [strange bugs](https://github.com/minetest/minetest/issues/11783).
+This works with players as well but you may experience [strange bugs](https://github.com/luanti-org/luanti/issues/11783).
 {{< /notice >}}
 
 ### `collisionbox`

--- a/content/docs/persistence.md
+++ b/content/docs/persistence.md
@@ -120,7 +120,7 @@ Use of the `data = assert(core.deserialize(lua, safe))` idiom is recommended.
 {{< /notice >}}
 
 {{< notice warning >}}
-[`core.deserialize` errors on large objects on LuaJIT](https://github.com/minetest/minetest/issues/7574)
+[`core.deserialize` errors on large objects on LuaJIT](https://github.com/luanti-org/luanti/issues/7574)
 {{< /notice >}}
 
 ## Engine-provided default persistence

--- a/content/docs/texture-modifiers.md
+++ b/content/docs/texture-modifiers.md
@@ -15,14 +15,14 @@ Texture modifiers are partially redundant with hardware colorization. Hardware c
 
 ## Performance Issues
 * All textures are generated on the CPU, not the GPU. Generation is therefore slow and may temporarily block the client thread.
-* Texture modifiers are [kept in client memory forever](https://github.com/minetest/minetest/issues/11531).
-* Cached texture modifiers are [not leveraged when generating new ones](https://github.com/minetest/minetest/issues/11587).
+* Texture modifiers are [kept in client memory forever](https://github.com/luanti-org/luanti/issues/11531).
+* Cached texture modifiers are [not leveraged when generating new ones](https://github.com/luanti-org/luanti/issues/11587).
 * Non-linear (at least quadratic) time complexity of the shotgun parser is possible.
 
 Use texture modifiers mostly statically. Keep dynamically generated textures to a minimum to not fill up the client cache over time. Don't force the client to perform many expensive texture generations in a small timespan if you want a smooth client experience. Do not create large, convoluted texture modifiers if possible.
 
 ## Bugs
-* Large texture modifiers may [freeze the client](https://github.com/minetest/minetest/issues/11829).
+* Large texture modifiers may [freeze the client](https://github.com/luanti-org/luanti/issues/11829).
 * Out-of-bound memory reads are possible using certain texture modifiers. Example: `[lowpart:0:blank.png`.
 * Out-of-bound pixels are often considered "full white" (`#FFFFFFFF`)
 * Certain invalid texture modifiers may lead to client segmentation faults.

--- a/content/engine-dev-process/code-style-guidelines.md
+++ b/content/engine-dev-process/code-style-guidelines.md
@@ -211,7 +211,7 @@ DoThingHere();//This does thing        <--- no!
 
 * Files should be named using _snake\_case_ style.
 * Files should have includes for everything that they depend on. Don't depend on, eg, `"util/numeric.h"` including `<string>`!
-* Uniqueness when compiling headers is ensured by using `#pragma once`. ([Accepted by all coredevs](https://github.com/minetest/minetest/issues/6259))
+* Uniqueness when compiling headers is ensured by using `#pragma once`. ([Accepted by all coredevs](https://github.com/luanti-org/luanti/issues/6259))
 
 ```cpp
 #pragma once

--- a/content/engine-dev-process/git-guidelines.md
+++ b/content/engine-dev-process/git-guidelines.md
@@ -47,7 +47,7 @@ Rule 1 is **only** applied to the `minetest/minetest` and `minetest/minetest_gam
 
 #### Notes
 
-\[1\] Upstream is at [https://github.com/minetest/minetest](https://github.com/minetest/minetest)
+\[1\] Upstream is at [https://github.com/luanti-org/luanti](https://github.com/luanti-org/luanti)
 
 \[2\] The team: [https://github.com/orgs/minetest/people](https://github.com/orgs/minetest/people)
 
@@ -58,15 +58,15 @@ Rule 1 is **only** applied to the `minetest/minetest` and `minetest/minetest_gam
 Issue and Pull-Request Management
 ---------------------------------
 
-* If an issue is a duplicate, post "duplicate of #ISSUENUM", label as [Duplicate](https://github.com/minetest/minetest/labels/Duplicate), and close the issue. Newer issues should be considered duplicates of older issues, unless the newer issue has more useful conversation. Information from the duplicate issue can also be edited into the open issue.
+* If an issue is a duplicate, post "duplicate of #ISSUENUM", label as [Duplicate](https://github.com/luanti-org/luanti/labels/Duplicate), and close the issue. Newer issues should be considered duplicates of older issues, unless the newer issue has more useful conversation. Information from the duplicate issue can also be edited into the open issue.
 * If a pull request or an issue does not get a response from its author within one month when requiring more details, it is closed.
-    * Use ["Action / change needed"](https://github.com/minetest/minetest/labels/Action%20%2F%20change%20needed) and ["User feedback needed"](https://github.com/minetest/minetest/labels/User%20feedback%20needed)
+    * Use ["Action / change needed"](https://github.com/luanti-org/luanti/labels/Action%20%2F%20change%20needed) and ["User feedback needed"](https://github.com/luanti-org/luanti/labels/User%20feedback%20needed)
 * Core devs who reviewed a PR once should stay with the PR for additional review rounds. Loss of interest (thus unsubscribing) should be signalled properly.
     * This is best communicated by assigning yourself to the PR using the GitHub feature.
     * PR assignments show who's taking care of the PR; leaving the option to @ them to progress.
-* [WIP](https://github.com/minetest/minetest/labels/WIP) / draft pull-requests that are not updated within 6 months should be closed.
-* Use [Project Boards](https://github.com/minetest/minetest/projects) to prioritise and order issues and pull requests.
-* The [Possible Close](https://github.com/minetest/minetest/labels/Possible%20Close) label can be used to warn authors of impending closure.
+* [WIP](https://github.com/luanti-org/luanti/labels/WIP) / draft pull-requests that are not updated within 6 months should be closed.
+* Use [Project Boards](https://github.com/luanti-org/luanti/projects) to prioritise and order issues and pull requests.
+* The [Possible Close](https://github.com/luanti-org/luanti/labels/Possible%20Close) label can be used to warn authors of impending closure.
 
 ### Triagers
 

--- a/content/engine-dev-process/meetings.md
+++ b/content/engine-dev-process/meetings.md
@@ -32,7 +32,7 @@ Add your points here. Most important comes first.
 
 Also consider:
 
-* ["One Approval" PRs](https://github.com/minetest/minetest/pulls?q=is%3Apr+is%3Aopen+label%3A%22One+approval+%E2%9C%85+%E2%97%BB%EF%B8%8F%22) and decide on whether to merge, request changes or close.
+* ["One Approval" PRs](https://github.com/luanti-org/luanti/pulls?q=is%3Apr+is%3Aopen+label%3A%22One+approval+%E2%9C%85+%E2%97%BB%EF%B8%8F%22) and decide on whether to merge, request changes or close.
 
 Past Meetings
 -------------
@@ -44,7 +44,7 @@ Past Meetings
 
 * Feature freeze time (Zughy)
     * Feature freeze has started. Still undecided about what to do with SDL2
-* PLEASE finish the [renaming process](https://github.com/minetest/minetest/issues/15322) before FOSDEM (Zughy)
+* PLEASE finish the [renaming process](https://github.com/luanti-org/luanti/issues/15322) before FOSDEM (Zughy)
     * Luanti organisation has been created on GitHub, the rest is in the works. For more details see the [IRC log](https://irc.minetest.net/minetest-dev/2025-01-19#i_6236220)
 
 2024-12-22
@@ -57,14 +57,14 @@ Past Meetings
 
 **PR discussion/reviews**
 
-* https://github.com/minetest/minetest/pulls?q=is%3Apr+is%3Aopen+scancodes
+* https://github.com/luanti-org/luanti/pulls?q=is%3Apr+is%3Aopen+scancodes
 
 2024-12-08
 ----------
 
 **Organization Discussion**
 
-* Finish renaming Minetest -> Luanti ([issue](https://github.com/minetest/minetest/issues/15322), Zughy)
+* Finish renaming Minetest -> Luanti ([issue](https://github.com/luanti-org/luanti/issues/15322), Zughy)
     * Not finished, but steps forwards were made
 
 2024-11-10
@@ -108,8 +108,8 @@ Meeting: [https://irc.minetest.net/minetest-dev/2024-10-13#i\_6208356](https://i
 
 **Organization Discussion**
 
-* 5.9.1: [https://github.com/minetest/minetest/milestone/27](https://github.com/minetest/minetest/milestone/27)
-* [Add gameid aliases](https://github.com/minetest/minetest/issues/14543) (herowl)
+* 5.9.1: [https://github.com/luanti-org/luanti/milestone/27](https://github.com/luanti-org/luanti/milestone/27)
+* [Add gameid aliases](https://github.com/luanti-org/luanti/issues/14543) (herowl)
 * (low priority) Future development cycle idea by pgimeno. Almost permanent feature freeze. (again, Krock)
     * Idea submission: [https://irc.minetest.net/minetest-dev/2024-07-17#i\_6185892](https://irc.minetest.net/minetest-dev/2024-07-17#i_6185892)
     * Meeting discussion 1: [https://irc.minetest.net/minetest-dev/2024-08-04#i\_6189904](https://irc.minetest.net/minetest-dev/2024-08-04#i_6189904)
@@ -122,15 +122,15 @@ Meeting: [https://irc.minetest.net/minetest-dev/2024-10-13#i\_6208356](https://i
 
 **Organization Discussion**
 
-* 5.9.1: [https://github.com/minetest/minetest/milestone/27](https://github.com/minetest/minetest/milestone/27)
+* 5.9.1: [https://github.com/luanti-org/luanti/milestone/27](https://github.com/luanti-org/luanti/milestone/27)
     * Currently 10 PRs ready (merged) that could be included. Not all milestone issues will be fixed in time.
-* [Separate repo for requesting and discussing new features](https://github.com/minetest/minetest/issues/11568). See [here and next page](https://irc.minetest.net/minetest-dev/2024-09-01#i_6197652) for further info (Zughy)
+* [Separate repo for requesting and discussing new features](https://github.com/luanti-org/luanti/issues/11568). See [here and next page](https://irc.minetest.net/minetest-dev/2024-09-01#i_6197652) for further info (Zughy)
     * A few core devs tend to be opposed to this idea. For a definitive result, a poll might be appropriate.
 
 2024-08-18
 ----------
 
-* 5.9.1: [https://github.com/minetest/minetest/milestone/27](https://github.com/minetest/minetest/milestone/27)
+* 5.9.1: [https://github.com/luanti-org/luanti/milestone/27](https://github.com/luanti-org/luanti/milestone/27)
     * Went though one by one
 
 2024-08-04
@@ -140,11 +140,11 @@ Meeting: [https://irc.minetest.net/minetest-dev/2024-10-13#i\_6208356](https://i
 
 * Finalise 5.9 (Zughy)
     * SDL character lookup issue:
-    * `SDL_GetScancodeFromKey(SDLK_SLASH)` idea from _y5nw_ --> [https://github.com/minetest/minetest/pull/14894](https://github.com/minetest/minetest/pull/14894) (hacky workaround, updated)
+    * `SDL_GetScancodeFromKey(SDLK_SLASH)` idea from _y5nw_ --> [https://github.com/luanti-org/luanti/pull/14894](https://github.com/luanti-org/luanti/pull/14894) (hacky workaround, updated)
     * See also: meeting discussion
 * Future development cycle idea by pgimeno. Almost permanent feature freeze. [https://irc.minetest.net/minetest-dev/2024-07-17#i\_6185892](https://irc.minetest.net/minetest-dev/2024-07-17#i_6185892) (Krock)
     * [https://irc.minetest.net/minetest-dev/2024-08-04#i\_6189904](https://irc.minetest.net/minetest-dev/2024-08-04#i_6189904)
-* [https://github.com/minetest/minetest/pull/13987](https://github.com/minetest/minetest/pull/13987) (observers)
+* [https://github.com/luanti-org/luanti/pull/13987](https://github.com/luanti-org/luanti/pull/13987) (observers)
     * Krock will check code paths to determine the risks.
 
 2024-07-21
@@ -156,7 +156,7 @@ Meeting: [https://irc.minetest.net/minetest-dev/2024-10-13#i\_6208356](https://i
 
 **PR discussion/reviews**
 
-* [https://github.com/minetest/minetest/pull/14749#issuecomment-2222747966](https://github.com/minetest/minetest/pull/14749#issuecomment-2222747966) opinions needed
+* [https://github.com/luanti-org/luanti/pull/14749#issuecomment-2222747966](https://github.com/luanti-org/luanti/pull/14749#issuecomment-2222747966) opinions needed
     * Krock: "sfan5's comment seems like a good workaround. I could open a PR for that if it's what we'd want"
 
 2024-04-28
@@ -172,7 +172,7 @@ Meeting: [https://irc.minetest.net/minetest-dev/2024-10-13#i\_6208356](https://i
 
 **PR discussion/reviews**
 
-* [3d line rendering](https://github.com/minetest/minetest/pull/13020#issuecomment-1944150506): thoughts on grorp's primitive suggestion (Zughy)
+* [3d line rendering](https://github.com/luanti-org/luanti/pull/13020#issuecomment-1944150506): thoughts on grorp's primitive suggestion (Zughy)
     * [https://irc.minetest.net/minetest-dev/2024-03-03#i\_6156739](https://irc.minetest.net/minetest-dev/2024-03-03#i_6156739)
     * general agreement to grorp's comment
     * low priority for PR author as of now
@@ -183,7 +183,7 @@ Meeting: [https://irc.minetest.net/minetest-dev/2024-10-13#i\_6208356](https://i
     * 14319 (nil puncher): answered
     * 14347 (pointing range): sfan5 is on it, Desour maybe too
     * 14369 (preserve metatables): appguru is on it
-* [Camera API (draft)](https://github.com/minetest/minetest/pull/14325)
+* [Camera API (draft)](https://github.com/luanti-org/luanti/pull/14325)
     * Questions & inputs: [https://irc.minetest.net/minetest-dev/2024-03-03#i\_6156971](https://irc.minetest.net/minetest-dev/2024-03-03#i_6156971)
 
 2024-02-18
@@ -201,11 +201,11 @@ Meeting: [https://irc.minetest.net/minetest-dev/2024-10-13#i\_6208356](https://i
 
 **PR discussion/reviews**
 
-* [Simplify bug report form](https://github.com/minetest/minetest/pull/14154): stale, we should take a decision (Zughy)
+* [Simplify bug report form](https://github.com/luanti-org/luanti/pull/14154): stale, we should take a decision (Zughy)
     * { Desour, sfan5 } for a simple text template, { rubenwardy, Krock } against
-* [bulk\_get\_node](https://github.com/minetest/minetest/pull/14225) Worth or not? (Krock)
+* [bulk\_get\_node](https://github.com/luanti-org/luanti/pull/14225) Worth or not? (Krock)
     * appgurueu might look into it again to judge the reliability of the performance tests
-    * node get/set speedup PR: [https://github.com/minetest/minetest/pull/14384](https://github.com/minetest/minetest/pull/14384)
+    * node get/set speedup PR: [https://github.com/luanti-org/luanti/pull/14384](https://github.com/luanti-org/luanti/pull/14384)
 
 2024-01-21
 ----------
@@ -220,14 +220,14 @@ Meeting: [https://irc.minetest.net/minetest-dev/2024-10-13#i\_6208356](https://i
 
 **PR discussion/reviews**
 
-* What to do about [Add drawtype sunken and covered](https://github.com/minetest/minetest/pull/14103), see my comment (Zughy)
+* What to do about [Add drawtype sunken and covered](https://github.com/luanti-org/luanti/pull/14103), see my comment (Zughy)
     * Left a summary of the discussion (Krock)
 * When can we have [Reformat the code irr#248](https://github.com/minetest/irrlicht/pull/248), and irrlicht merge? (DS)
     * Only irr#276 would be nice to have merged before import
     * Added a milestone for Feb 4 to keep track of the waiting PRs.
 * [Irrlicht build fix](https://github.com/minetest/irrlicht/pull/281) - I would be grateful about some opinions. (Krock)
     * PR updated with sfan5's suggestion.
-* [Inventory stack swap fixes](https://github.com/minetest/minetest/pull/12595) - asking who would have time to review it (Krock)
+* [Inventory stack swap fixes](https://github.com/luanti-org/luanti/pull/12595) - asking who would have time to review it (Krock)
     * Potential reviewers informed.
 
 2023-12-10
@@ -244,7 +244,7 @@ Meeting: [https://irc.minetest.net/minetest-dev/2024-10-13#i\_6208356](https://i
 **Organization Discussion**
 
 * 5.8.0 release
-    * The [Formspec Android fix](https://github.com/minetest/minetest/pull/13872) should be merged beforehand (Krock)
+    * The [Formspec Android fix](https://github.com/luanti-org/luanti/pull/13872) should be merged beforehand (Krock)
         * grorp also looked into it, without any progress
         * Waiting on progress from any contributor
 * Final answer about internal discussion #71 (Zughy)
@@ -252,9 +252,9 @@ Meeting: [https://irc.minetest.net/minetest-dev/2024-10-13#i\_6208356](https://i
 
 **PR discussion/reviews**
 
-* Can anyone please check the log in [CJK characters looks been filtered in chat\_message while the GUI could display them collectly](https://github.com/minetest/minetest/issues/13813#issuecomment-1730594420) so to understand what to do with the issue? (Zughy)
+* Can anyone please check the log in [CJK characters looks been filtered in chat\_message while the GUI could display them collectly](https://github.com/luanti-org/luanti/issues/13813#issuecomment-1730594420) so to understand what to do with the issue? (Zughy)
     * Krock took care of it, ball in OP's court
-* [HUD/Formspec replacement PR](https://github.com/minetest/minetest/pull/12926) status update? (json (IRC) via Krock)
+* [HUD/Formspec replacement PR](https://github.com/luanti-org/luanti/pull/12926) status update? (json (IRC) via Krock)
 
 2023-10-15
 ----------
@@ -279,18 +279,18 @@ Mainly a revisit of all milestone points without specific PR reviews.
         * Voted for +2 weeks time to get this done.
         * Caveat: rubenwardy and grorp will not be available much in the next few weeks
     * Feature freeze on Oct 15, release on Oct 29
-    * [LTO optimization](https://github.com/minetest/minetest/issues/13192) is not a blocker. Can be moved to 5.9.0 if needed.
-* [Settings UI tracker](https://github.com/minetest/minetest/issues/13476) - Plenty of merged PRs, how much is still required for 5.8.0? (Krock)
+    * [LTO optimization](https://github.com/luanti-org/luanti/issues/13192) is not a blocker. Can be moved to 5.9.0 if needed.
+* [Settings UI tracker](https://github.com/luanti-org/luanti/issues/13476) - Plenty of merged PRs, how much is still required for 5.8.0? (Krock)
     * Non-blocking issues for an eventual release.
 
 **PR discussion/reviews**
 
-* [Dual wield](https://github.com/minetest/minetest/pull/11016) - Feedback brainstorming (Krock)
+* [Dual wield](https://github.com/luanti-org/luanti/pull/11016) - Feedback brainstorming (Krock)
     * Responded.
 
 Concept approval for:
 
-* [Liquid system](https://github.com/minetest/minetest/pull/13764) - Concept yes/no? (Krock)
+* [Liquid system](https://github.com/luanti-org/luanti/pull/13764) - Concept yes/no? (Krock)
     * Concept approved. Waiting for performance test results.
 
 2023-09-17
@@ -300,26 +300,26 @@ Concept approval for:
 
 * Feature freeze? (Zughy)
     * Milestone set to Oct 15 for feature freeze on Oct 1 (possibly a dev meeting day) (Krock)
-    * Reserved additional time to assign milestones and to solve the MTG\_follow-up issue [https://github.com/minetest/minetest/issues/13800](https://github.com/minetest/minetest/issues/13800)
+    * Reserved additional time to assign milestones and to solve the MTG\_follow-up issue [https://github.com/luanti-org/luanti/issues/13800](https://github.com/luanti-org/luanti/issues/13800)
 
 **PR discussion/reviews**
 
-* [Import Irrlicht](https://github.com/minetest/minetest/pull/13642) (wsor4035)
+* [Import Irrlicht](https://github.com/luanti-org/luanti/pull/13642) (wsor4035)
     * Generally agreed but needs addressing Desour's requirements before merge
     * It will have to be merged eventually (sfan5)
-* [Code style guidelines for Java code](https://github.com/minetest/minetest/pull/13700) There are already guidelines for C++ and Lua code, but not (Android-specific) Java code. It can be as simple as, "Use Android Studio's linter/formatter." (srifqi)
+* [Code style guidelines for Java code](https://github.com/luanti-org/luanti/pull/13700) There are already guidelines for C++ and Lua code, but not (Android-specific) Java code. It can be as simple as, "Use Android Studio's linter/formatter." (srifqi)
     * Volunteers are welcome to extend this page, e.g. srifqi: [/Android\_code\_style\_guidelines](/Android_code_style_guidelines)
-* A follow up for [Issue 13583](https://github.com/minetest/minetest/issues/13583): Is there a draft already that I missed? This can be great for documenting supported OS/env. (srifqi)
+* A follow up for [Issue 13583](https://github.com/luanti-org/luanti/issues/13583): Is there a draft already that I missed? This can be great for documenting supported OS/env. (srifqi)
     * The suggested document is currently WIP
     * Be clear how old toolchains we support, e.g. by supported Ubuntu LTS versions to use newer libraries or C++ revisions (Krock)
-* [Dual Wielding](https://github.com/minetest/minetest/pull/11016) has been waiting for a feedback since 6 months. Since we're busy, I'd suggest to prioritise MTG removal and postpone this feature to 5.9, so that core devs can review it without any pressure (Zughy)
+* [Dual Wielding](https://github.com/luanti-org/luanti/pull/11016) has been waiting for a feedback since 6 months. Since we're busy, I'd suggest to prioritise MTG removal and postpone this feature to 5.9, so that core devs can review it without any pressure (Zughy)
     * No progress and the issues could yet not be solved. Removed milestone, marked as draft.
 
 Concept approval for:
 
-* [Refactored the liquid system, and added an optional feature for liquids to flow to the next slope](https://github.com/minetest/minetest/pull/13764)
+* [Refactored the liquid system, and added an optional feature for liquids to flow to the next slope](https://github.com/luanti-org/luanti/pull/13764)
     * Comment written to clarify the situation (Krock)
-* [Fix liquid falling if in "float" group](https://github.com/minetest/minetest/pull/13789)
+* [Fix liquid falling if in "float" group](https://github.com/luanti-org/luanti/pull/13789)
     * Concept approved by Krock
 
 2023-06-25
@@ -327,17 +327,17 @@ Concept approval for:
 
 **Organization Discussion**
 
-* Start considering a hypothetical new name, possibly privately. See [Here](https://github.com/minetest/minetest/issues/13510) (Zughy)
+* Start considering a hypothetical new name, possibly privately. See [Here](https://github.com/luanti-org/luanti/issues/13510) (Zughy)
     * Will be discussed internally
 
 **PR discussion/reviews**
 
-* Less than two months to [5.8](https://github.com/minetest/minetest/milestone/22): we should consider what to do with a few issues/PRs in the milestone to avoid a last month burst (Zughy)
+* Less than two months to [5.8](https://github.com/luanti-org/luanti/milestone/22): we should consider what to do with a few issues/PRs in the milestone to avoid a last month burst (Zughy)
     * Not yet urgent. PRs and issues will be resolved when people have time for it.
 
 Also discussed:
 
-* [Debundle Minetest Game](https://github.com/minetest/minetest/issues/13550)
+* [Debundle Minetest Game](https://github.com/luanti-org/luanti/issues/13550)
     * Question about "featured" marks to make it more visible to newcomers
 
 2023-05-28
@@ -350,8 +350,8 @@ Also discussed:
 
 **PR discussion/reviews**
 
-* Discuss and concept approve or close ["Roadmap: needs approval" PRs](https://github.com/minetest/minetest/pulls?q=is%3Aopen+is%3Apr+label%3A%22Roadmap%3A+Needs+approval%22)
-    * [make falling node checks check for protection](https://github.com/minetest/minetest/pull/12966) TL;DR: Some server made ladders falling, and protection doesn't protect from fall through on\_punch by other players. Possible solutions include making the registered on\_punch/on\_dig/on\_placenode function overwritable, or only checking for protection in on\_punch. What to do? (DS)
+* Discuss and concept approve or close ["Roadmap: needs approval" PRs](https://github.com/luanti-org/luanti/pulls?q=is%3Aopen+is%3Apr+label%3A%22Roadmap%3A+Needs+approval%22)
+    * [make falling node checks check for protection](https://github.com/luanti-org/luanti/pull/12966) TL;DR: Some server made ladders falling, and protection doesn't protect from fall through on\_punch by other players. Possible solutions include making the registered on\_punch/on\_dig/on\_placenode function overwritable, or only checking for protection in on\_punch. What to do? (DS)
         * Removed roadmap approval needed label. (DS)
 
 2023-05-14
@@ -364,7 +364,7 @@ Also discussed:
 
 **PR discussion/reviews**
 
-* ["Dual Wielding"](https://github.com/minetest/minetest/pull/11016) I think OP is waiting for a core dev feedback, see their last comment (Zughy)
+* ["Dual Wielding"](https://github.com/luanti-org/luanti/pull/11016) I think OP is waiting for a core dev feedback, see their last comment (Zughy)
     * ???
 
 2023-04-30
@@ -379,14 +379,14 @@ Notes inherited from the meeting 2023-04-16
 
 **PR discussion/reviews**
 
-* ["Move code style guidelines into repo"](https://github.com/minetest/minetest/pull/12749) Do we want this? (I'm myself neutral now that code blocks are no longer broken on the wiki.) (DS)
+* ["Move code style guidelines into repo"](https://github.com/luanti-org/luanti/pull/12749) Do we want this? (I'm myself neutral now that code blocks are no longer broken on the wiki.) (DS)
     * Generally okay but updating it might be cumbersome. Guidelines should apply to all Minetest (group) projects (Krock)
     * Closed by author (DS).
-* ["Conditional textures for nodes, bulk texture changing"](https://github.com/minetest/minetest/issues/13417) Support for this? Or for the alternative linked in the original post? Or none? (Zughy)
+* ["Conditional textures for nodes, bulk texture changing"](https://github.com/luanti-org/luanti/issues/13417) Support for this? Or for the alternative linked in the original post? Or none? (Zughy)
     * Yet another feature request. No interest shown. Marked as low priority.
-* ["Add utility script to update/generate \*.tr files"](https://github.com/minetest/minetest/pull/13464) roadmap approval or rejection?
-    * Answer posted in [https://github.com/minetest/minetest/pull/13437](https://github.com/minetest/minetest/pull/13437)
-* [Irrlicht as a submodule](https://github.com/minetest/minetest/pull/13215) - how to fix Android compatibility? Ideas are welcome.
+* ["Add utility script to update/generate \*.tr files"](https://github.com/luanti-org/luanti/pull/13464) roadmap approval or rejection?
+    * Answer posted in [https://github.com/luanti-org/luanti/pull/13437](https://github.com/luanti-org/luanti/pull/13437)
+* [Irrlicht as a submodule](https://github.com/luanti-org/luanti/pull/13215) - how to fix Android compatibility? Ideas are welcome.
     * Fix the Android script later? Waiting on numberZero when they have time (Krock)
 
 2023-04-02
@@ -424,17 +424,17 @@ Notes inherited from the meeting 2023-04-16
 
 **PR discussion/reviews**
 
-* ["SSCSM execution"](https://github.com/minetest/minetest/pull/13046) (TurkeyMcMac)
+* ["SSCSM execution"](https://github.com/luanti-org/luanti/pull/13046) (TurkeyMcMac)
     * Should the PR be reviewed in parts? If so, it can be reviewed at this point.
     * It would be good to divide up the work of implementing the various SSCSM APIs, if other people have time to work on this. See the TODO list in the PR description. To see how to implement SSCSM APIs, you can look at src/script/lua\_api/l\_csm.cpp and src/script/lua\_api/l\_csm\_nodemeta.cpp.
     * Meeting note: x2048 might have a look at it. It should be merged in small chunks, preferably with unittests (Krock)
-* ["Reorder client initialization"](https://github.com/minetest/minetest/pull/12189#issuecomment-1130461922) needs sfan's take to unlock the status of the PR (Zughy)
+* ["Reorder client initialization"](https://github.com/luanti-org/luanti/pull/12189#issuecomment-1130461922) needs sfan's take to unlock the status of the PR (Zughy)
     * sfan5 unblocked it; will be reviewed when time comes.
-* [MariaDB](https://github.com/minetest/minetest/pull/13266) Yes or No (Krock: Yes) - who could test this easily? (Krock)
+* [MariaDB](https://github.com/luanti-org/luanti/pull/13266) Yes or No (Krock: Yes) - who could test this easily? (Krock)
     * obsolete entry
-* ["Dual Wielding"](https://github.com/minetest/minetest/pull/11016) How should we go ahead with this? (sfan5)
+* ["Dual Wielding"](https://github.com/luanti-org/luanti/pull/11016) How should we go ahead with this? (sfan5)
     * Yes: item definition flag (sfan5 answered)
-* [Add world-independent storage directory for mods](https://github.com/minetest/minetest/pull/12315) - approved, but there's concerns about how multiple instances of Minetest running will cause issues for modders. Is this acceptable? What should modders do in these situations? Is the design fundamentally flawed (rubenwardy)
+* [Add world-independent storage directory for mods](https://github.com/luanti-org/luanti/pull/12315) - approved, but there's concerns about how multiple instances of Minetest running will cause issues for modders. Is this acceptable? What should modders do in these situations? Is the design fundamentally flawed (rubenwardy)
     * Ideas: callback-based updates for sane locking (sfan5)
 
 2023-01-08
@@ -442,7 +442,7 @@ Notes inherited from the meeting 2023-04-16
 
 **Organization Discussion**
 
-* ["Host the generated Lua API documentation under api.minetest.net"](https://github.com/minetest/minetest/issues/13072) (Zughy)
+* ["Host the generated Lua API documentation under api.minetest.net"](https://github.com/luanti-org/luanti/issues/13072) (Zughy)
     * Assigned to rubenwardy to move it to GitHub
 * Feature freeze starting on January 22? I suggest to keep every feature currently listed in the milestone (Zughy)
     * focus on the Privacy Policy (sample available)
@@ -452,11 +452,11 @@ Notes inherited from the meeting 2023-04-16
 
 **PR discussion/reviews**
 
-* ["Static binary builds for Linux on common architectures"](https://github.com/minetest/minetest/issues/13037): yes, no? (Zughy)
+* ["Static binary builds for Linux on common architectures"](https://github.com/luanti-org/luanti/issues/13037): yes, no? (Zughy)
     * AppImages are coming and Docker is an universal solution. Additional static binaries are not necessary.
-* ["Allow zoom even with overwritten default FOV"](https://github.com/minetest/minetest/pull/12953): There seems to be some disagreement on this in the comments. Is the change acceptable? (TurkeyMcMac)
+* ["Allow zoom even with overwritten default FOV"](https://github.com/luanti-org/luanti/pull/12953): There seems to be some disagreement on this in the comments. Is the change acceptable? (TurkeyMcMac)
     * Handled (Krock)
-* ["Add node texture variants"](https://github.com/minetest/minetest/pull/12928): What item properties should be allowed to vary by variant? (TurkeyMcMac)
+* ["Add node texture variants"](https://github.com/luanti-org/luanti/pull/12928): What item properties should be allowed to vary by variant? (TurkeyMcMac)
     * Currently supported: "tiles", "overlay\_tiles", and "special\_tiles"
     * Others that could be supported:
         * "inventory\_image" and "wield\_image": May be unnecessary as there's a separate PR for settings these using item metadata.
@@ -471,12 +471,12 @@ Notes inherited from the meeting 2023-04-16
 
 * 5.7 release when? (Zughy)
     * somewhen in January is good (rubenwardy, sfan5)
-* we should decide on the [new roadmap](https://github.com/minetest/minetest/issues/12746) (sfan5)
+* we should decide on the [new roadmap](https://github.com/luanti-org/luanti/issues/12746) (sfan5)
     * Commented an analysis of the previous roadmap and suggestions on how to increase "success rate" (Krock)
 
 **PR discussion/reviews**
 
-* ["Dual wielding"](https://github.com/minetest/minetest/pull/11016): can someone please take care of this PR if the author doesn't come back? It's a huge feature for modders (Zughy)
+* ["Dual wielding"](https://github.com/luanti-org/luanti/pull/11016): can someone please take care of this PR if the author doesn't come back? It's a huge feature for modders (Zughy)
     * Author came back. Check the progress as usual.
 
 2022-10-23
@@ -484,17 +484,17 @@ Notes inherited from the meeting 2023-04-16
 
 **PR discussion/reviews**
 
-* [Add vector() constructor](https://github.com/minetest/minetest/pull/12772) - It seems this proposal is controversial. Its fate should be decided. (TurkeyMcMac)
+* [Add vector() constructor](https://github.com/luanti-org/luanti/pull/12772) - It seems this proposal is controversial. Its fate should be decided. (TurkeyMcMac)
 
 2022-10-09
 ----------
 
 **PR discussion/reviews**
 
-* [Add support for attached facedir/4dir nodes (comment)](https://github.com/minetest/minetest/pull/11432#issuecomment-1263562675) - Thoughts on adding this as part of the PR? (TurkeyMcMac)
-* [Add callback on\_mapblocks\_changed](https://github.com/minetest/minetest/pull/12739) - Decide whether this is the right approach. We could go for something with node granularity, but it would probably be more expensive. (TurkeyMcMac)
-* [Implement some VoxelManip functionality safely using LuaJIT's FFI library](https://github.com/minetest/minetest/pull/12611) - Decide whether the added complexity is worth it. (TurkeyMcMac)
-* [Use .md extension for markdown files](https://github.com/minetest/minetest/pull/12449) - Please decide once and for all (Zughy)
+* [Add support for attached facedir/4dir nodes (comment)](https://github.com/luanti-org/luanti/pull/11432#issuecomment-1263562675) - Thoughts on adding this as part of the PR? (TurkeyMcMac)
+* [Add callback on\_mapblocks\_changed](https://github.com/luanti-org/luanti/pull/12739) - Decide whether this is the right approach. We could go for something with node granularity, but it would probably be more expensive. (TurkeyMcMac)
+* [Implement some VoxelManip functionality safely using LuaJIT's FFI library](https://github.com/luanti-org/luanti/pull/12611) - Decide whether the added complexity is worth it. (TurkeyMcMac)
+* [Use .md extension for markdown files](https://github.com/luanti-org/luanti/pull/12449) - Please decide once and for all (Zughy)
 * Shader brightness issue
 
 2022-09-25
@@ -502,15 +502,15 @@ Notes inherited from the meeting 2023-04-16
 
 **PR discussion/reviews**
 
-* [Set visibility of players/hide them from others](https://github.com/minetest/minetest/pull/9863) has been rebased twice, it's from 2020. Can anyone have a look at it? Or put it in the 5.7.0 milestone, I don't know (Zughy)
-* [New physics modifiers](https://github.com/minetest/minetest/pull/11465) concept discussion (Wuzzy)
-* The same goes for [Show relative screenshot filename on chat when applicable](https://github.com/minetest/minetest/pull/9776) (Zughy)
+* [Set visibility of players/hide them from others](https://github.com/luanti-org/luanti/pull/9863) has been rebased twice, it's from 2020. Can anyone have a look at it? Or put it in the 5.7.0 milestone, I don't know (Zughy)
+* [New physics modifiers](https://github.com/luanti-org/luanti/pull/11465) concept discussion (Wuzzy)
+* The same goes for [Show relative screenshot filename on chat when applicable](https://github.com/luanti-org/luanti/pull/9776) (Zughy)
 
 2022-09-11
 ----------
 
-* [Item pickup](https://github.com/minetest/minetest/pull/7712) general concept discussion
-* [Item movement unit tests](https://github.com/minetest/minetest/pull/11885) required for bugfix PR [#12595](https://github.com/minetest/minetest/pull/12595)
+* [Item pickup](https://github.com/luanti-org/luanti/pull/7712) general concept discussion
+* [Item movement unit tests](https://github.com/luanti-org/luanti/pull/11885) required for bugfix PR [#12595](https://github.com/luanti-org/luanti/pull/12595)
 
 2022-08-28
 ----------
@@ -518,21 +518,21 @@ Notes inherited from the meeting 2023-04-16
 **Organization Discussion**
 
 * Add some bugs to the 5.6.1 milestone? (Proposal: each core dev pick one and adds it)
-* Two years have passed since the [first roadmap brainstorm](https://github.com/minetest/minetest/issues/10461): create another one to then follow after 5.7? Also to gather feedback
+* Two years have passed since the [first roadmap brainstorm](https://github.com/luanti-org/luanti/issues/10461): create another one to then follow after 5.7? Also to gather feedback
 
 **PR discussion/reviews**
 
-* [Use .md extension for markdown files](https://github.com/minetest/minetest/pull/12449) - yes or no?
-* [Doc of set\_sun/-moon: Absolute orientation and difference in scale](https://github.com/minetest/minetest/pull/12145) \- document difference in size or slightly change the scale of both the celestial bodies?
+* [Use .md extension for markdown files](https://github.com/luanti-org/luanti/pull/12449) - yes or no?
+* [Doc of set\_sun/-moon: Absolute orientation and difference in scale](https://github.com/luanti-org/luanti/pull/12145) \- document difference in size or slightly change the scale of both the celestial bodies?
 
 2022-08-14
 ----------
 
 **PR discussion/reviews**
 
-* [https://github.com/minetest/minetest/issues?q=is%3Aopen+is%3Aissue+label%3AQuestion](https://github.com/minetest/minetest/issues?q=is%3Aopen+is%3Aissue+label%3AQuestion)
-* [Add minetest.get\_player\_window\_information()](https://github.com/minetest/minetest/pull/12367) - any requirements for merge?
-* [Settings redesign](https://github.com/minetest/minetest/pull/12480) - how to resolve issues with focus?
+* [https://github.com/luanti-org/luanti/issues?q=is%3Aopen+is%3Aissue+label%3AQuestion](https://github.com/luanti-org/luanti/issues?q=is%3Aopen+is%3Aissue+label%3AQuestion)
+* [Add minetest.get\_player\_window\_information()](https://github.com/luanti-org/luanti/pull/12367) - any requirements for merge?
+* [Settings redesign](https://github.com/luanti-org/luanti/pull/12480) - how to resolve issues with focus?
 
 2022-07-31
 ----------
@@ -544,18 +544,18 @@ Notes inherited from the meeting 2023-04-16
 
 **PR discussion/reviews**
 
-* Work on merging the last PRs left in [the milestone](https://github.com/minetest/minetest/milestone/19)
+* Work on merging the last PRs left in [the milestone](https://github.com/luanti-org/luanti/milestone/19)
 
 2022-07-17
 ----------
 
 **PR discussion/reviews**
 
-* review [5.6.0 Milestone](https://github.com/minetest/minetest/milestone/19)
+* review [5.6.0 Milestone](https://github.com/luanti-org/luanti/milestone/19)
 
 Also consider:
 
-* ["One Approval" PRs](https://github.com/minetest/minetest/pulls?q=is%3Aopen+is%3Apr+label%3A%22One+approval%22) and decide on whether to merge, request changes or close.
+* ["One Approval" PRs](https://github.com/luanti-org/luanti/pulls?q=is%3Aopen+is%3Apr+label%3A%22One+approval%22) and decide on whether to merge, request changes or close.
     * in particular decide whether we want them for 5.6
 
 2022-07-03
@@ -568,35 +568,35 @@ Also consider:
 
 **PR discussion/reviews**
 
-* [Add minetest.get\_player\_window\_information()](https://github.com/minetest/minetest/pull/12367)
+* [Add minetest.get\_player\_window\_information()](https://github.com/luanti-org/luanti/pull/12367)
     * How to resist fingerprinting? -> minor concern, rounding is possible
     * Move to player ObjectRef? -> player-specific function. not necessarily.
     * Should this be prioritised for 5.6? ->
-* [Show dep errors in Select Mods modal](https://github.com/minetest/minetest/pull/12284) - pls someone review
+* [Show dep errors in Select Mods modal](https://github.com/luanti-org/luanti/pull/12284) - pls someone review
     * review shall be done
-* [Settings redesign](https://github.com/minetest/minetest/pull/12480) - concept approval, prioritisation, requirements for submission
+* [Settings redesign](https://github.com/luanti-org/luanti/pull/12480) - concept approval, prioritisation, requirements for submission
     * "yes but not in 5.6"
-* [Bouncy improvements](https://github.com/minetest/minetest/pull/11939) - makes trampolines fun again.
+* [Bouncy improvements](https://github.com/luanti-org/luanti/pull/11939) - makes trampolines fun again.
     * review shall be done
-* [repeat\_place\_time](https://github.com/minetest/minetest/issues/12493) - what do to about this?
+* [repeat\_place\_time](https://github.com/luanti-org/luanti/issues/12493) - what do to about this?
     * Krock: write a bounds check or removal PR
 
 Roadmapped
 
-* [FOV mouse sensitivity](https://github.com/minetest/minetest/pull/12483)
-* [http client fetch](https://github.com/minetest/minetest/pull/12463)
+* [FOV mouse sensitivity](https://github.com/luanti-org/luanti/pull/12483)
+* [http client fetch](https://github.com/luanti-org/luanti/pull/12463)
     * not needed
-* [fix acceleration](https://github.com/minetest/minetest/pull/12353) / [fix gravity calculation](https://github.com/minetest/minetest/pull/11855)
+* [fix acceleration](https://github.com/luanti-org/luanti/pull/12353) / [fix gravity calculation](https://github.com/luanti-org/luanti/pull/11855)
     * approved
-* [allow server to use media from texture\_path](https://github.com/minetest/minetest/pull/10850)
+* [allow server to use media from texture\_path](https://github.com/luanti-org/luanti/pull/10850)
     * flawed, but possibly helpful
-* [Only count entity as "on ground" if they are colliding on the Y axis](https://github.com/minetest/minetest/pull/10587)
+* [Only count entity as "on ground" if they are colliding on the Y axis](https://github.com/luanti-org/luanti/pull/10587)
     * Krock + sfan5: rejected.
-* [userdata command line option](https://github.com/minetest/minetest/pull/9424)
+* [userdata command line option](https://github.com/luanti-org/luanti/pull/9424)
     * OK, but needs changes
-* [Add keep\_newlines argument to wrap\_text](https://github.com/minetest/minetest/pull/7728)
+* [Add keep\_newlines argument to wrap\_text](https://github.com/luanti-org/luanti/pull/7728)
     * OK, might need fixing
-* [Add an item pick up callback (2)](https://github.com/minetest/minetest/pull/7712)
+* [Add an item pick up callback (2)](https://github.com/luanti-org/luanti/pull/7712)
     * seems useful.
 
 2022-06-05
@@ -609,8 +609,8 @@ Roadmapped
 
 **PR discussion/reviews**
 
-* [Make minetest.write\_json use empty list instead of "null" for empty tables](https://github.com/minetest/minetest/pull/12168) - is this approach good?
-* [Raise default windowed resolution to 1280x720 (720p)](https://github.com/minetest/minetest/pull/12355) - yes or no?
+* [Make minetest.write\_json use empty list instead of "null" for empty tables](https://github.com/luanti-org/luanti/pull/12168) - is this approach good?
+* [Raise default windowed resolution to 1280x720 (720p)](https://github.com/luanti-org/luanti/pull/12355) - yes or no?
     * no
 
 2022-05-22
@@ -618,11 +618,11 @@ Roadmapped
 
 **PR discussion/reviews**
 
-* [#11545](https://github.com/minetest/minetest/pull/11545) <- someone should review this --[Sfan5](/User:Sfan5 "User:Sfan5") ([talk](/index.php?title=User_talk:Sfan5&action=edit&redlink=1 "User talk:Sfan5 (page does not exist)"))
+* [#11545](https://github.com/luanti-org/luanti/pull/11545) <- someone should review this --[Sfan5](/User:Sfan5 "User:Sfan5") ([talk](/index.php?title=User_talk:Sfan5&action=edit&redlink=1 "User talk:Sfan5 (page does not exist)"))
     * x2048
-* [#12367](https://github.com/minetest/minetest/pull/12367) some questions here
+* [#12367](https://github.com/luanti-org/luanti/pull/12367) some questions here
     * mostly answered before meeting
-* [https://github.com/minetest/minetest/issues/12353](https://github.com/minetest/minetest/issues/12353) -- Fix acceleration by appgurueu
+* [https://github.com/luanti-org/luanti/issues/12353](https://github.com/luanti-org/luanti/issues/12353) -- Fix acceleration by appgurueu
 
 2022-05-08
 ----------
@@ -636,13 +636,13 @@ Roadmapped
 
 **PR discussion/reviews**
 
-* [#11251 (comment)](https://github.com/minetest/minetest/issues/12251#issuecomment-1115477945) - backwards compat hinders refactors, drop compat for old irrmt revisions this time?
+* [#11251 (comment)](https://github.com/luanti-org/luanti/issues/12251#issuecomment-1115477945) - backwards compat hinders refactors, drop compat for old irrmt revisions this time?
     * _<+rubenwardy> anyway. I think the conclusion is that breaking it is fine, with some concerns over ease-of-use during dev_
 
 Also consider:
 
-* ["One Approval" PRs](https://github.com/minetest/minetest/pulls?q=is%3Aopen+is%3Apr+label%3A%22One+approval%22) and decide on whether to merge, request changes or close.
-* ["Roadmap: needs approval" PRs](https://github.com/minetest/minetest/pulls?q=is%3Aopen+is%3Apr+label%3A%22Roadmap%3A+Needs+approval%22)
+* ["One Approval" PRs](https://github.com/luanti-org/luanti/pulls?q=is%3Aopen+is%3Apr+label%3A%22One+approval%22) and decide on whether to merge, request changes or close.
+* ["Roadmap: needs approval" PRs](https://github.com/luanti-org/luanti/pulls?q=is%3Aopen+is%3Apr+label%3A%22Roadmap%3A+Needs+approval%22)
 * oldest PRs
 
 2022-04-24
@@ -651,45 +651,45 @@ Also consider:
 **Organization Discussion**
 
 * What to do with closing out old PRs? Should we start assessing old PRs under the roadmap / assigning people?
-    * Yes, start marking PRs as supported by core dev / roadmap / needs approval. [https://github.com/minetest/minetest/pulls?q=is%3Aopen+is%3Apr+-label%3ARoadmap+-label%3ABugfix+-label%3A%22Supported+by+core+dev%22+sort%3Acreated-asc+](https://github.com/minetest/minetest/pulls?q=is%3Aopen+is%3Apr+-label%3ARoadmap+-label%3ABugfix+-label%3A%22Supported+by+core+dev%22+sort%3Acreated-asc+)
+    * Yes, start marking PRs as supported by core dev / roadmap / needs approval. [https://github.com/luanti-org/luanti/pulls?q=is%3Aopen+is%3Apr+-label%3ARoadmap+-label%3ABugfix+-label%3A%22Supported+by+core+dev%22+sort%3Acreated-asc+](https://github.com/luanti-org/luanti/pulls?q=is%3Aopen+is%3Apr+-label%3ARoadmap+-label%3ABugfix+-label%3A%22Supported+by+core+dev%22+sort%3Acreated-asc+)
 * Release in June?
     * Potentially, will discuss 5.6.0 goals in next meeting
 
 **Issues/planning**
 
-* See proposal in [Optional dependencies being overridden/turned into hard dependencies](https://github.com/minetest/minetest/issues/8601)
+* See proposal in [Optional dependencies being overridden/turned into hard dependencies](https://github.com/luanti-org/luanti/issues/8601)
     * Accepted
-* [Calling set\_detach() + set\_properties() + set\_pos() on the same step fails to teleport the player half of the time, especially online](https://github.com/minetest/minetest/issues/12092)
+* [Calling set\_detach() + set\_properties() + set\_pos() on the same step fails to teleport the player half of the time, especially online](https://github.com/luanti-org/luanti/issues/12092)
     * Marked as confirmed, to be investigated
 
 **PR discussion/reviews**
 
-* Close [Shader improvements: Saturation Optimization](https://github.com/minetest/minetest/pull/11854)?
+* Close [Shader improvements: Saturation Optimization](https://github.com/luanti-org/luanti/pull/11854)?
     * Closed.
 
 Roadmap: needs approval
 
-* [Single functions to get/set every celestial vault element](https://github.com/minetest/minetest/pull/12181)
+* [Single functions to get/set every celestial vault element](https://github.com/luanti-org/luanti/pull/12181)
     * Approved.
-* [Make debug.g/setmetatable respect the "\_\_metatable\_debug" metatable field](https://github.com/minetest/minetest/pull/12118)
+* [Make debug.g/setmetatable respect the "\_\_metatable\_debug" metatable field](https://github.com/luanti-org/luanti/pull/12118)
     * Postponed for further inputs.
-* [WIP: Do not stat /etc/localtime all the time](https://github.com/minetest/minetest/pull/12080)
+* [WIP: Do not stat /etc/localtime all the time](https://github.com/luanti-org/luanti/pull/12080)
     * Needs actions or will be closed.
-* [Add mods list formspec display for /mods cmd](https://github.com/minetest/minetest/pull/11946)
+* [Add mods list formspec display for /mods cmd](https://github.com/luanti-org/luanti/pull/11946)
     * Approved but needs a better implementation.
 
 High-level/Concept approval for:
 
-* [Add support for translating content title and descriptions](https://github.com/minetest/minetest/pull/12208)
+* [Add support for translating content title and descriptions](https://github.com/luanti-org/luanti/pull/12208)
     * Inputs provided.
-* [Add login/register dialog to separate login/register](https://github.com/minetest/minetest/pull/12185)
+* [Add login/register dialog to separate login/register](https://github.com/luanti-org/luanti/pull/12185)
     * Inputs provided.
 
 Other:
 
-* New spatial index library for entity lookup performance improvements [12040](https://github.com/minetest/minetest/pull/12040)
+* New spatial index library for entity lookup performance improvements [12040](https://github.com/luanti-org/luanti/pull/12040)
     * Library needs checking, first PR should also replace existing spatial lib
-* [Add bulk ABMs by TurkeyMcMac](https://github.com/minetest/minetest/issues/12128)
+* [Add bulk ABMs by TurkeyMcMac](https://github.com/luanti-org/luanti/issues/12128)
     * Unsure of the question, skipped
 
 2022-04-10
@@ -706,28 +706,28 @@ Other:
 
 Also have a look at "One Approval" PRs and decide on whether to merge, request changes or close.
 
-* [SQLite media cache](https://github.com/minetest/minetest/pull/11567)
+* [SQLite media cache](https://github.com/luanti-org/luanti/pull/11567)
     * Closed for lack of benchmarks. Opinion is split on whether sqlite is a good approach
-* [proller's breaking world](https://github.com/minetest/minetest/pull/11843)
+* [proller's breaking world](https://github.com/luanti-org/luanti/pull/11843)
     * Closed due to scale of changes vs prioritisation. Agreement made that a hard network break should not be done
-* [Add API function minetest.activate\_objects\_in\_area](https://github.com/minetest/minetest/pull/11630)
+* [Add API function minetest.activate\_objects\_in\_area](https://github.com/luanti-org/luanti/pull/11630)
     * worth more consideration, posted comment in PR
-* [CSM settings](https://github.com/minetest/minetest/pull/12131)
+* [CSM settings](https://github.com/luanti-org/luanti/pull/12131)
     * Supported by core dev
-* [Add text tile modifier](https://github.com/minetest/minetest/issues/12084)
+* [Add text tile modifier](https://github.com/luanti-org/luanti/issues/12084)
     * Closed as draft and bad approach
-* [Restore and enhance bouncy behavior by pecksin](https://github.com/minetest/minetest/issues/11939)
+* [Restore and enhance bouncy behavior by pecksin](https://github.com/luanti-org/luanti/issues/11939)
     * Supported by core dev
-* [Dual Wielding](https://github.com/minetest/minetest/issues/11016)
+* [Dual Wielding](https://github.com/luanti-org/luanti/issues/11016)
     * concept accepted, no need for an arbitrary amount of wields
-* [A light\_source should not override sunlight](https://github.com/minetest/minetest/issues/11933)
+* [A light\_source should not override sunlight](https://github.com/luanti-org/luanti/issues/11933)
     * Krock brought up an implementation concern
-* [Add rotation support for wallmounted nodes in 'ceiling' or 'floor' mode](https://github.com/minetest/minetest/pull/11073)
+* [Add rotation support for wallmounted nodes in 'ceiling' or 'floor' mode](https://github.com/luanti-org/luanti/pull/11073)
     * concept accepted
 
 **MTG discussion/reviews**
 
-* [Don't block fluid (water, lava) flow by flowers, mushrooms, grass and saplings](https://github.com/minetest/minetest_game/pull/2942)
+* [Don't block fluid (water, lava) flow by flowers, mushrooms, grass and saplings](https://github.com/luanti-org/luanti_game/pull/2942)
     * Does this break builds? Does this count as a feature? **\->** Closed as too close to a feature
 
 2021-09-04
@@ -744,18 +744,18 @@ Add your points here. Most important comes first.
 * Irrlicht milestone
     * Await hecks' OpenGL rewrite until beginning of October.
     * .. otherwise remove shadowmap main menu setting and disable within C++
-* ItemStack metadata network optimizations - [https://github.com/minetest/minetest/pull/11014](https://github.com/minetest/minetest/pull/11014)
+* ItemStack metadata network optimizations - [https://github.com/luanti-org/luanti/pull/11014](https://github.com/luanti-org/luanti/pull/11014)
     * Closed.
-* Automatic selection of mods - Adopt or Won't add - [https://github.com/minetest/minetest/pull/11274](https://github.com/minetest/minetest/pull/11274)
+* Automatic selection of mods - Adopt or Won't add - [https://github.com/luanti-org/luanti/pull/11274](https://github.com/luanti-org/luanti/pull/11274)
     * Closed.
-* Death item duplication and callback fix - [https://github.com/minetest/minetest/pull/11445](https://github.com/minetest/minetest/pull/11445)
-* Joystick controls - [https://github.com/minetest/minetest/pull/11262](https://github.com/minetest/minetest/pull/11262)
-* New movement tweak (trivial) - [https://github.com/minetest/minetest/pull/11367](https://github.com/minetest/minetest/pull/11367)
+* Death item duplication and callback fix - [https://github.com/luanti-org/luanti/pull/11445](https://github.com/luanti-org/luanti/pull/11445)
+* Joystick controls - [https://github.com/luanti-org/luanti/pull/11262](https://github.com/luanti-org/luanti/pull/11262)
+* New movement tweak (trivial) - [https://github.com/luanti-org/luanti/pull/11367](https://github.com/luanti-org/luanti/pull/11367)
     * To be discussed later.
-* Perhaps provide an alternative fix for [https://github.com/minetest/minetest/issues/9725](https://github.com/minetest/minetest/issues/9725)
+* Perhaps provide an alternative fix for [https://github.com/luanti-org/luanti/issues/9725](https://github.com/luanti-org/luanti/issues/9725)
 * TODO reviews
-    * Dynamic Media V2 [https://github.com/minetest/minetest/issues/11550](https://github.com/minetest/minetest/issues/11550)
-    * Animated particle spanwers [https://github.com/minetest/minetest/issues/11545](https://github.com/minetest/minetest/issues/11545)
+    * Dynamic Media V2 [https://github.com/luanti-org/luanti/issues/11550](https://github.com/luanti-org/luanti/issues/11550)
+    * Animated particle spanwers [https://github.com/luanti-org/luanti/issues/11545](https://github.com/luanti-org/luanti/issues/11545)
 
 Also have a look at "One Approval" PRs and decide on whether to merge, request changes or close.
 
@@ -769,7 +769,7 @@ Also have a look at "One Approval" PRs and decide on whether to merge, request c
 * SDL2 integration into Irrlicht
     * Ensure that adding an "original Irrlicht" compatibility mode is somehow possible if necessary (ex. Android). (mentioned by sfan5)
     * Development on a separate branch to merge when it's usable
-    * SDL2 as Irrlicht device. WIP (nerzhul) [https://github.com/minetest/minetest/pull/10780](https://github.com/minetest/minetest/pull/10780)
+    * SDL2 as Irrlicht device. WIP (nerzhul) [https://github.com/luanti-org/luanti/pull/10780](https://github.com/luanti-org/luanti/pull/10780)
     * SDL2 for text input. WIP (numzero)
 
 * Plans for 5.4.0 and feature freeze
@@ -777,29 +777,29 @@ Also have a look at "One Approval" PRs and decide on whether to merge, request c
 
 **PR discussion/reviews**
 
-* [https://github.com/minetest/minetest/issues/9352](https://github.com/minetest/minetest/issues/9352) get\_player\_information issue
+* [https://github.com/luanti-org/luanti/issues/9352](https://github.com/luanti-org/luanti/issues/9352) get\_player\_information issue
     * No solution yet.
 
-* [https://github.com/minetest/minetest/pull/10693](https://github.com/minetest/minetest/pull/10693) Builtin translate
+* [https://github.com/luanti-org/luanti/pull/10693](https://github.com/luanti-org/luanti/pull/10693) Builtin translate
     * Needs re-review. Soon ready for merge prior 5.4.0 freeze
 
-* [https://github.com/minetest/minetest/pull/10636](https://github.com/minetest/minetest/pull/10636) Android, ready for review.
+* [https://github.com/luanti-org/luanti/pull/10636](https://github.com/luanti-org/luanti/pull/10636) Android, ready for review.
     * Gradle error is fixed in master (rebase)
     * rubenwardy will review/test
 
-* [https://github.com/minetest/minetest/pull/10083](https://github.com/minetest/minetest/pull/10083) Inventory slots style
+* [https://github.com/luanti-org/luanti/pull/10083](https://github.com/luanti-org/luanti/pull/10083) Inventory slots style
     * Waiting for merge or another approval (v-rob)
 
-* [https://github.com/minetest/minetest/issues/10555](https://github.com/minetest/minetest/issues/10555) Game settings bug
-    * Fix Settings for once and all in 5.4.0: [https://github.com/minetest/minetest/pull/10819](https://github.com/minetest/minetest/pull/10819)
+* [https://github.com/luanti-org/luanti/issues/10555](https://github.com/luanti-org/luanti/issues/10555) Game settings bug
+    * Fix Settings for once and all in 5.4.0: [https://github.com/luanti-org/luanti/pull/10819](https://github.com/luanti-org/luanti/pull/10819)
 
-* [https://github.com/minetest/minetest/pull/10265](https://github.com/minetest/minetest/pull/10265) Formspec image features
+* [https://github.com/luanti-org/luanti/pull/10265](https://github.com/luanti-org/luanti/pull/10265) Formspec image features
     * Considered for 5.4.0 prior freeze, but not priority
 
 **MTG discussion/reviews**
 
-* [https://github.com/minetest/minetest\_game/pull/2803](https://github.com/minetest/minetest_game/pull/2803) Texture compression issue
-    * Based on issue [https://github.com/minetest/minetest\_game/issues/2801](https://github.com/minetest/minetest_game/issues/2801)
+* [https://github.com/luanti-org/luanti\_game/pull/2803](https://github.com/luanti-org/luanti_game/pull/2803) Texture compression issue
+    * Based on issue [https://github.com/luanti-org/luanti\_game/issues/2801](https://github.com/luanti-org/luanti_game/issues/2801)
     * imagefilters.cpp imageCleanTransparent() might need fixing to get white-filled opaque leaves after adding colors to the texture
     * Affected textures are whitelisted, but ExeVirus review that again
 
@@ -811,15 +811,15 @@ Also have a look at "One Approval" PRs and decide on whether to merge, request c
 * 5.3.1 or 5.4.0 release date? There have been multiple big security fixes.
     * Perhaps January, depending on how quickly the milestone issues can be resolved
     * Texture alpha warnings issue: sfan5 needs time to work on it
-    * game settings fallback issue: needs decision whether to fix overrideDefaults() or the whole Settings structure ([https://github.com/minetest/minetest/issues/10555](https://github.com/minetest/minetest/issues/10555))
+    * game settings fallback issue: needs decision whether to fix overrideDefaults() or the whole Settings structure ([https://github.com/luanti-org/luanti/issues/10555](https://github.com/luanti-org/luanti/issues/10555))
 
 **PR discussion/reviews**
 
 Various concepts to judge:
 
-* [https://github.com/minetest/minetest/pull/10384](https://github.com/minetest/minetest/pull/10384) image transparency
-* [https://github.com/minetest/minetest/pull/10430](https://github.com/minetest/minetest/pull/10430) mapgen constant
-* [https://github.com/minetest/minetest/pull/10516](https://github.com/minetest/minetest/pull/10516) base64 (2)
+* [https://github.com/luanti-org/luanti/pull/10384](https://github.com/luanti-org/luanti/pull/10384) image transparency
+* [https://github.com/luanti-org/luanti/pull/10430](https://github.com/luanti-org/luanti/pull/10430) mapgen constant
+* [https://github.com/luanti-org/luanti/pull/10516](https://github.com/luanti-org/luanti/pull/10516) base64 (2)
 
 **MTG discussion/reviews**
 
@@ -830,10 +830,10 @@ Logs: [http://irc.minetest.net/minetest-dev/2020-10-03#i\_5738345](http://irc.mi
 
 **Organization Discussion**
 
-* 5.4.0 release plan -> December? [https://github.com/minetest/minetest/milestone/17](https://github.com/minetest/minetest/milestone/17)
+* 5.4.0 release plan -> December? [https://github.com/luanti-org/luanti/milestone/17](https://github.com/luanti-org/luanti/milestone/17)
     * \-> Rough approximated date for release (after 6 months)
 * Roadmap - everyone list 3 goals for development (ie: Improve UI), this can then be condensed into a roadmap of goals.
-    * \-> [https://github.com/minetest/minetest/issues/10461](https://github.com/minetest/minetest/issues/10461)
+    * \-> [https://github.com/luanti-org/luanti/issues/10461](https://github.com/luanti-org/luanti/issues/10461)
 * Add trusted contributors as issue triagers. [https://github.com/orgs/minetest/teams/engine/discussions/25](https://github.com/orgs/minetest/teams/engine/discussions/25)
     * Suggested users: Wuzzy, Calinou. Wuzzy was already offered core dev, but refused.
     * They would help ensure issue quality (asking for information, editing, closing duplicated) and oragnise issues (labelling, prioritising)
@@ -843,10 +843,10 @@ Logs: [http://irc.minetest.net/minetest-dev/2020-10-03#i\_5738345](http://irc.mi
 
 **PR discussion/reviews**
 
-* Decide on a "use\_texture\_alpha" solution: [https://github.com/minetest/minetest/issues/10342](https://github.com/minetest/minetest/issues/10342)
+* Decide on a "use\_texture\_alpha" solution: [https://github.com/luanti-org/luanti/issues/10342](https://github.com/luanti-org/luanti/issues/10342)
     * \-> sfan5 will take care of it
-* Adopt or modify anticheat fix: [https://github.com/minetest/minetest/pull/10340](https://github.com/minetest/minetest/pull/10340)
-* Require debug priv to view gameplay-relevant debug info (2nd try), add wireframe priv [https://github.com/minetest/minetest/pull/9315](https://github.com/minetest/minetest/pull/9315)
+* Adopt or modify anticheat fix: [https://github.com/luanti-org/luanti/pull/10340](https://github.com/luanti-org/luanti/pull/10340)
+* Require debug priv to view gameplay-relevant debug info (2nd try), add wireframe priv [https://github.com/luanti-org/luanti/pull/9315](https://github.com/luanti-org/luanti/pull/9315)
     * Requested by GreenXenith
     * \-> Will be reviewed...
 
@@ -860,32 +860,32 @@ Logs: [http://irc.minetest.net/minetest-dev/2020-10-03#i\_5738345](http://irc.mi
 * Theme of 5.4.0 (ie: what to focus on)
 * New core developers
     * New member invited
-* Minimal/Devtest policy: [https://github.com/minetest/minetest/issues/9645](https://github.com/minetest/minetest/issues/9645)
+* Minimal/Devtest policy: [https://github.com/luanti-org/luanti/issues/9645](https://github.com/luanti-org/luanti/issues/9645)
     * Wrote comment
 * minetest-mods.github.io needs a library update - could there be any problems? volunteers?
     * postpone, not so relevant
 
 **PR discussion/reviews**
 
-* HUD minimap: [https://github.com/minetest/minetest/pull/9079](https://github.com/minetest/minetest/pull/9079)
-* HUD compass: [https://github.com/minetest/minetest/pull/9312](https://github.com/minetest/minetest/pull/9312)
-* Relative ~coordinates: [https://github.com/minetest/minetest/pull/9588](https://github.com/minetest/minetest/pull/9588)
-* LuaEntitySAO API: [https://github.com/minetest/minetest/pull/9717](https://github.com/minetest/minetest/pull/9717)
+* HUD minimap: [https://github.com/luanti-org/luanti/pull/9079](https://github.com/luanti-org/luanti/pull/9079)
+* HUD compass: [https://github.com/luanti-org/luanti/pull/9312](https://github.com/luanti-org/luanti/pull/9312)
+* Relative ~coordinates: [https://github.com/luanti-org/luanti/pull/9588](https://github.com/luanti-org/luanti/pull/9588)
+* LuaEntitySAO API: [https://github.com/luanti-org/luanti/pull/9717](https://github.com/luanti-org/luanti/pull/9717)
     * Massive PR, but stalls. Needs clarification what to do
     * Incompatible with the recent on\_step moveresult changes
     * Krock: Some API functions might be superfluous (not generic enough), check later again
 
 **MTG discussion/reviews**
 
-* Wall extension (trivial): [https://github.com/minetest/minetest\_game/pull/2237](https://github.com/minetest/minetest_game/pull/2237)
-* Craftguide: [https://github.com/minetest/minetest\_game/pull/2396](https://github.com/minetest/minetest_game/pull/2396)
+* Wall extension (trivial): [https://github.com/luanti-org/luanti\_game/pull/2237](https://github.com/luanti-org/luanti_game/pull/2237)
+* Craftguide: [https://github.com/luanti-org/luanti\_game/pull/2396](https://github.com/luanti-org/luanti_game/pull/2396)
 
 2020-06-06
 ----------
 
 **Organisation Discussion**
 
-* Allow or deny UTF-8 characters in the source code? [relevant PR](https://github.com/minetest/minetest/pull/9828)
+* Allow or deny UTF-8 characters in the source code? [relevant PR](https://github.com/luanti-org/luanti/pull/9828)
     * Many different encodings. Non-ASCII characters should be avoided [http://irc.minetest.net/minetest-dev/2020-06-06#i\_5698515](http://irc.minetest.net/minetest-dev/2020-06-06#i_5698515)
 * Translations and minetest.conf.example need updating. Volunteers?
     * Reminder. Will be done when feature freeze starts.
@@ -895,12 +895,12 @@ Logs: [http://irc.minetest.net/minetest-dev/2020-10-03#i\_5738345](http://irc.mi
 
 **PR discussion/reviews**
 
-* [POC: Introduce SerializeStream helper class](https://github.com/minetest/minetest/pull/9914)
+* [POC: Introduce SerializeStream helper class](https://github.com/luanti-org/luanti/pull/9914)
     * Split input/output stream and polish for a real PR.
 
 **Suspected issues**
 
-* [network desync](https://github.com/minetest/minetest/issues/9592)
+* [network desync](https://github.com/luanti-org/luanti/issues/9592)
     * sfan5: [http://irc.minetest.net/minetest-dev/2020-06-06#i\_5698555](http://irc.minetest.net/minetest-dev/2020-06-06#i_5698555) not important for release, networking limits
 * Wireframe glitch (graphics related)
     * Driver issue. Wait for AMD to fix their stuff
@@ -913,20 +913,20 @@ Most important first.
 **Organisation Discussion**
 
 * Release date for 5.2.0: March 14, if possible
-* Open issues: [https://github.com/minetest/minetest/issues?q=is%3Aissue+is%3Aopen+label%3ABlocker](https://github.com/minetest/minetest/issues?q=is%3Aissue+is%3Aopen+label%3ABlocker)
-    * Sky fix: [https://github.com/minetest/minetest/pull/9472](https://github.com/minetest/minetest/pull/9472)
+* Open issues: [https://github.com/luanti-org/luanti/issues?q=is%3Aissue+is%3Aopen+label%3ABlocker](https://github.com/luanti-org/luanti/issues?q=is%3Aissue+is%3Aopen+label%3ABlocker)
+    * Sky fix: [https://github.com/luanti-org/luanti/pull/9472](https://github.com/luanti-org/luanti/pull/9472)
     * Entity shader fix: (none yet)
 
 **PR discussion/reviews**
 
-* Delayed for 5.3.0: Android XXL PR [https://github.com/minetest/minetest/pull/9066](https://github.com/minetest/minetest/pull/9066)
-    * Fix dependencies in [https://github.com/minetest/minetest\_android\_deps\_binaries](https://github.com/minetest/minetest_android_deps_binaries)
+* Delayed for 5.3.0: Android XXL PR [https://github.com/luanti-org/luanti/pull/9066](https://github.com/luanti-org/luanti/pull/9066)
+    * Fix dependencies in [https://github.com/luanti-org/luanti\_android\_deps\_binaries](https://github.com/luanti-org/luanti_android_deps_binaries)
     * Startup crash needs fixing
     * Build script works (sfan5)
 
 **MTG discussion/reviews**
 
-* Probably 5.3.0 or later: Craft guide: [https://github.com/minetest/minetest\_game/pull/2396](https://github.com/minetest/minetest_game/pull/2396)
+* Probably 5.3.0 or later: Craft guide: [https://github.com/luanti-org/luanti\_game/pull/2396](https://github.com/luanti-org/luanti_game/pull/2396)
     * Should this be added in 5.2 or not?
 
 2020-01-11
@@ -943,13 +943,13 @@ Most important first.
 
 **PR discussion/reviews**
 
-* Formspec text cursor feature [https://github.com/minetest/minetest/pull/8665](https://github.com/minetest/minetest/pull/8665)
-* Scroll container [https://github.com/minetest/minetest/pull/9101](https://github.com/minetest/minetest/pull/9101)
-* Images in tabs [https://github.com/minetest/minetest/pull/8621](https://github.com/minetest/minetest/pull/8621)
+* Formspec text cursor feature [https://github.com/luanti-org/luanti/pull/8665](https://github.com/luanti-org/luanti/pull/8665)
+* Scroll container [https://github.com/luanti-org/luanti/pull/9101](https://github.com/luanti-org/luanti/pull/9101)
+* Images in tabs [https://github.com/luanti-org/luanti/pull/8621](https://github.com/luanti-org/luanti/pull/8621)
 
 **MTG discussion/reviews**
 
-* Craftguide from pauloue [https://github.com/minetest/minetest\_game/pull/2396](https://github.com/minetest/minetest_game/pull/2396)
+* Craftguide from pauloue [https://github.com/luanti-org/luanti\_game/pull/2396](https://github.com/luanti-org/luanti_game/pull/2396)
 
 2019-08-10
 ----------
@@ -958,14 +958,14 @@ Arranged by: Krock
 
 **PR discussion/reviews**
 
-* Custom particle generators for particle spawners [https://github.com/minetest/minetest/pull/6688](https://github.com/minetest/minetest/pull/6688)
+* Custom particle generators for particle spawners [https://github.com/luanti-org/luanti/pull/6688](https://github.com/luanti-org/luanti/pull/6688)
     * Should this be closed?
-* Fix debug.txt growing bigger and bigger [https://github.com/minetest/minetest/pull/8382](https://github.com/minetest/minetest/pull/8382)
+* Fix debug.txt growing bigger and bigger [https://github.com/luanti-org/luanti/pull/8382](https://github.com/luanti-org/luanti/pull/8382)
     * What to change? Or reject & close?
-* Punchwear [https://github.com/minetest/minetest/pull/6804](https://github.com/minetest/minetest/pull/6804)
+* Punchwear [https://github.com/luanti-org/luanti/pull/6804](https://github.com/luanti-org/luanti/pull/6804)
     * Who wants to adopt it? The feature was requested many times.
-* Add support for set\_formspec\_prepend in main menu [https://github.com/minetest/minetest/pull/8611](https://github.com/minetest/minetest/pull/8611)
-* Hide chat when console is open [https://github.com/minetest/minetest/pull/8656](https://github.com/minetest/minetest/pull/8656)
+* Add support for set\_formspec\_prepend in main menu [https://github.com/luanti-org/luanti/pull/8611](https://github.com/luanti-org/luanti/pull/8611)
+* Hide chat when console is open [https://github.com/luanti-org/luanti/pull/8656](https://github.com/luanti-org/luanti/pull/8656)
 
 2019-06-29
 ----------
@@ -976,24 +976,24 @@ Logs: [http://irc.minetest.net/minetest-dev/2019-06-29#i\_5561978](http://irc.mi
 
 **Organisation discussion**
 
-* Is 5.0.2 needed for the newlines in setting name bug? ([https://github.com/minetest/minetest/pull/8590](https://github.com/minetest/minetest/pull/8590))
+* Is 5.0.2 needed for the newlines in setting name bug? ([https://github.com/luanti-org/luanti/pull/8590](https://github.com/luanti-org/luanti/pull/8590))
     * Yet no clear decision
 * What is needed to have good mobs in Minetest (- Game)?
     * I suggest roping in mob devs like tenplus1 and stujones1
     * No blood included. Belongs to another mod
 * Combine pathfinder issues into a single issue
-    * [https://github.com/minetest/minetest/issues/8642](https://github.com/minetest/minetest/issues/8642)
-* Possible close issues/PRs: [https://github.com/minetest/minetest/pulls?q=is%3Apr+is%3Aopen+sort%3Aupdated-desc+label%3A%22Possible+close%22](https://github.com/minetest/minetest/pulls?q=is%3Apr+is%3Aopen+sort%3Aupdated-desc+label%3A%22Possible+close%22)
+    * [https://github.com/luanti-org/luanti/issues/8642](https://github.com/luanti-org/luanti/issues/8642)
+* Possible close issues/PRs: [https://github.com/luanti-org/luanti/pulls?q=is%3Apr+is%3Aopen+sort%3Aupdated-desc+label%3A%22Possible+close%22](https://github.com/luanti-org/luanti/pulls?q=is%3Apr+is%3Aopen+sort%3Aupdated-desc+label%3A%22Possible+close%22)
 * Does 1 disapproval block a PR?
     * SmallJoker seems to think it does
 
 **Proposed order of merging formspec PRs**
 
-The idea is to merge the most important PR first (top of list) to not drown in conflicts: **[https://github.com/minetest/minetest/projects/6](https://github.com/minetest/minetest/projects/6)**
+The idea is to merge the most important PR first (top of list) to not drown in conflicts: **[https://github.com/luanti-org/luanti/projects/6](https://github.com/luanti-org/luanti/projects/6)**
 
-* style\[\] [https://github.com/minetest/minetest/pull/8383](https://github.com/minetest/minetest/pull/8383)
-* scroll\_container\[\] [https://github.com/minetest/minetest/pull/8591](https://github.com/minetest/minetest/pull/8591)
-* list spacing [https://github.com/minetest/minetest/pull/7971](https://github.com/minetest/minetest/pull/7971) (perhaps integrate into style\[\]?)
+* style\[\] [https://github.com/luanti-org/luanti/pull/8383](https://github.com/luanti-org/luanti/pull/8383)
+* scroll\_container\[\] [https://github.com/luanti-org/luanti/pull/8591](https://github.com/luanti-org/luanti/pull/8591)
+* list spacing [https://github.com/luanti-org/luanti/pull/7971](https://github.com/luanti-org/luanti/pull/7971) (perhaps integrate into style\[\]?)
 * Unarelith's refactors
 
 2018-July-August
@@ -1012,9 +1012,9 @@ Arranged by: Krock
 
 **PR discussion/reviews**
 
-* Colorize command parameters and privilege names ([https://github.com/minetest/minetest/pull/7019](https://github.com/minetest/minetest/pull/7019))
+* Colorize command parameters and privilege names ([https://github.com/luanti-org/luanti/pull/7019](https://github.com/luanti-org/luanti/pull/7019))
     * Improves readability - does it need \`string.format\` for a possibly prettier code?
-* Protocol cleanups [https://github.com/minetest/minetest/pull/7348](https://github.com/minetest/minetest/pull/7348)
+* Protocol cleanups [https://github.com/luanti-org/luanti/pull/7348](https://github.com/luanti-org/luanti/pull/7348)
     * Review needed (compat break)
 
 2018-06-??
@@ -1026,19 +1026,19 @@ Arranged by: Krock
 
 * Will there be a 0.4.18 release?
 * Bugfixing the bugfix release
-    * [https://github.com/minetest/minetest/commit/014a1a08](https://github.com/minetest/minetest/commit/014a1a08) fix for [https://github.com/minetest/minetest/issues/6092](https://github.com/minetest/minetest/issues/6092)
-    * [https://github.com/minetest/minetest/commit/a1598e1b](https://github.com/minetest/minetest/commit/a1598e1b) (c\_internal.cpp only) fix for [https://github.com/minetest/minetest/issues/7419](https://github.com/minetest/minetest/issues/7419)
+    * [https://github.com/luanti-org/luanti/commit/014a1a08](https://github.com/luanti-org/luanti/commit/014a1a08) fix for [https://github.com/luanti-org/luanti/issues/6092](https://github.com/luanti-org/luanti/issues/6092)
+    * [https://github.com/luanti-org/luanti/commit/a1598e1b](https://github.com/luanti-org/luanti/commit/a1598e1b) (c\_internal.cpp only) fix for [https://github.com/luanti-org/luanti/issues/7419](https://github.com/luanti-org/luanti/issues/7419)
 * Proposal: change master version scheme to: 5.0.0
 
 **PR discussion/reviews**
 
-* Colorize command parameters and privilege names ([https://github.com/minetest/minetest/pull/7019](https://github.com/minetest/minetest/pull/7019))
+* Colorize command parameters and privilege names ([https://github.com/luanti-org/luanti/pull/7019](https://github.com/luanti-org/luanti/pull/7019))
     * Improves readability - does it need \`string.format\` for a possibly prettier code?
-* Lua parameter reading [https://github.com/minetest/minetest/pull/7410](https://github.com/minetest/minetest/pull/7410)
+* Lua parameter reading [https://github.com/luanti-org/luanti/pull/7410](https://github.com/luanti-org/luanti/pull/7410)
     * Good design concept? Comments?
-* Protocol cleanups [https://github.com/minetest/minetest/pull/7348](https://github.com/minetest/minetest/pull/7348)
+* Protocol cleanups [https://github.com/luanti-org/luanti/pull/7348](https://github.com/luanti-org/luanti/pull/7348)
     * Review needed (compat break)
-* CSM keypress - is this advantage acceptable? [https://github.com/minetest/minetest/pull/7008](https://github.com/minetest/minetest/pull/7008)
+* CSM keypress - is this advantage acceptable? [https://github.com/luanti-org/luanti/pull/7008](https://github.com/luanti-org/luanti/pull/7008)
     * Needs flavors to be added: [http://irc.minetest.net/minetest-dev/2018-06-11#i\_5329651](http://irc.minetest.net/minetest-dev/2018-06-11#i_5329651)
 
 2018-05-19
@@ -1053,14 +1053,14 @@ Proposed time: 18:00 UTC
 * 0.4.17 - backport missing fixes and set date for freeze
     * ~Android-specific fix for [https://pastebin.com/j4mjniaq](https://pastebin.com/j4mjniaq) must be added too (during freeze?)~
     * Needs buildbot fixes (404 packages)
-    * Backport [https://github.com/minetest/minetest/commit/4bb41a19d](https://github.com/minetest/minetest/commit/4bb41a19d) ([http://irc.minetest.net/minetest-dev/2018-05-19#i\_5310266](http://irc.minetest.net/minetest-dev/2018-05-19#i_5310266))
+    * Backport [https://github.com/luanti-org/luanti/commit/4bb41a19d](https://github.com/luanti-org/luanti/commit/4bb41a19d) ([http://irc.minetest.net/minetest-dev/2018-05-19#i\_5310266](http://irc.minetest.net/minetest-dev/2018-05-19#i_5310266))
 * 0.4.17 - set release date
 
 **PR discussion/reviews**
 
-* Colorize command parameters and privilege names ([https://github.com/minetest/minetest/pull/7019](https://github.com/minetest/minetest/pull/7019))
+* Colorize command parameters and privilege names ([https://github.com/luanti-org/luanti/pull/7019](https://github.com/luanti-org/luanti/pull/7019))
     * Improves readability - does it need \`string.format\` for a possibly prettier code?
-* Fix missing ignore textures ([https://github.com/minetest/minetest/pull/7326](https://github.com/minetest/minetest/pull/7326))
+* Fix missing ignore textures ([https://github.com/luanti-org/luanti/pull/7326](https://github.com/luanti-org/luanti/pull/7326))
     * Needs more dev opinions & reviewing
 
 2018-05-05
@@ -1081,9 +1081,9 @@ It's now almost a month since the last meeting - it time for the next one. Propo
 
 **PR discussion/reviews**
 
-* Colorize command parameters and privilege names ([https://github.com/minetest/minetest/pull/7019](https://github.com/minetest/minetest/pull/7019))
+* Colorize command parameters and privilege names ([https://github.com/luanti-org/luanti/pull/7019](https://github.com/luanti-org/luanti/pull/7019))
     * Improves readability - does it need \`string.format\` for a possibly prettier code?
-* Abort when trying to set a not registered node ([https://github.com/minetest/minetest/pull/7011](https://github.com/minetest/minetest/pull/7011))
+* Abort when trying to set a not registered node ([https://github.com/luanti-org/luanti/pull/7011](https://github.com/luanti-org/luanti/pull/7011))
     * Needs more dev opinions & reviewing
 
 2018-04-07
@@ -1099,15 +1099,15 @@ Arranged by: Krock
 
 **PR discussion/review**
 
-* Android joystick ([https://github.com/minetest/minetest/pull/7126](https://github.com/minetest/minetest/pull/7126))
-* Formspecs: Add a `<use_color_alpha>` parameter to the box\[\] element ([https://github.com/minetest/minetest/pull/7116](https://github.com/minetest/minetest/pull/7116))
+* Android joystick ([https://github.com/luanti-org/luanti/pull/7126](https://github.com/luanti-org/luanti/pull/7126))
+* Formspecs: Add a `<use_color_alpha>` parameter to the box\[\] element ([https://github.com/luanti-org/luanti/pull/7116](https://github.com/luanti-org/luanti/pull/7116))
     * Causes errors in-game for older clients but doesn't affect playability - merge or not?
-* Colorize command parameters and privilege names ([https://github.com/minetest/minetest/pull/7019](https://github.com/minetest/minetest/pull/7019))
+* Colorize command parameters and privilege names ([https://github.com/luanti-org/luanti/pull/7019](https://github.com/luanti-org/luanti/pull/7019))
     * Improves readability - does it need \`string.format\` for a possibly prettier code?
 
 **MTG discussion/reviews**
 
-* Tools: rebalance ([https://github.com/minetest/minetest\_game/issues/1681](https://github.com/minetest/minetest_game/issues/1681))
+* Tools: rebalance ([https://github.com/luanti-org/luanti\_game/issues/1681](https://github.com/luanti-org/luanti_game/issues/1681))
     * Needs either a levelling system and/or special abilities for different materials to add variety
     * paramat suggests removing bronze, which is incorrectly a stronger tool than steel ([http://irc.minetest.net/minetest-dev/2018-04-07#i\_5272959](http://irc.minetest.net/minetest-dev/2018-04-07#i_5272959))
     * Future mese concept: [http://irc.minetest.net/minetest-dev/2018-04-07#i\_5273013](http://irc.minetest.net/minetest-dev/2018-04-07#i_5273013)
@@ -1119,8 +1119,8 @@ Arranged by: Krock
 
 **PR discussion/reviews**
 
-* Introduce clang-tidy to the CI ([https://github.com/minetest/minetest/pull/6295](https://github.com/minetest/minetest/pull/6295))
-* Android joystick ([https://github.com/minetest/minetest/pull/7126](https://github.com/minetest/minetest/pull/7126))
+* Introduce clang-tidy to the CI ([https://github.com/luanti-org/luanti/pull/6295](https://github.com/luanti-org/luanti/pull/6295))
+* Android joystick ([https://github.com/luanti-org/luanti/pull/7126](https://github.com/luanti-org/luanti/pull/7126))
     * Minor change requests, discussion about joystick placement
 
 **0.4.17 release schedule**
@@ -1129,7 +1129,7 @@ Arranged by: Krock
     * Announced. 15 April 2018, see [https://forum.luanti.org/viewtopic.php?f=18&t=19905](https://forum.luanti.org/viewtopic.php?f=18&t=19905)
 * Any new, important bugfixes to backport?
     * Added the \`core.rotate\_node\` bugfix, otherwise probably not. It's pretty much stable.
-* Volunteer for cherry-picking the ToDo backport commits ([https://github.com/minetest/minetest/pull/6746](https://github.com/minetest/minetest/pull/6746))
+* Volunteer for cherry-picking the ToDo backport commits ([https://github.com/luanti-org/luanti/pull/6746](https://github.com/luanti-org/luanti/pull/6746))
     * `<sfan5>` probably me ([http://irc.minetest.net/minetest-dev/2018-03-31#i\_5264276](http://irc.minetest.net/minetest-dev/2018-03-31#i_5264276))
 
 2018-03-10
@@ -1149,17 +1149,17 @@ Arranged by: Krock
 
 **PR discussion/reviews**
 
-* Remove texture pack caching ([https://github.com/minetest/minetest/pull/6660](https://github.com/minetest/minetest/pull/6660))
-* Don’t create CSM script env ([https://github.com/minetest/minetest/pull/6951](https://github.com/minetest/minetest/pull/6951))
+* Remove texture pack caching ([https://github.com/luanti-org/luanti/pull/6660](https://github.com/luanti-org/luanti/pull/6660))
+* Don’t create CSM script env ([https://github.com/luanti-org/luanti/pull/6951](https://github.com/luanti-org/luanti/pull/6951))
     * Log: [http://irc.minetest.net/minetest-dev/2018-03-10#i\_5249625](http://irc.minetest.net/minetest-dev/2018-03-10#i_5249625)
-    * Needs improvement, questionable solution due request of server-provided CSM ([https://github.com/minetest/minetest/issues/5393](https://github.com/minetest/minetest/issues/5393))
-* “Bugfix” for 0.4-backported rotate\_node calls ([https://github.com/minetest/minetest/pull/6900](https://github.com/minetest/minetest/pull/6900))
+    * Needs improvement, questionable solution due request of server-provided CSM ([https://github.com/luanti-org/luanti/issues/5393](https://github.com/luanti-org/luanti/issues/5393))
+* “Bugfix” for 0.4-backported rotate\_node calls ([https://github.com/luanti-org/luanti/pull/6900](https://github.com/luanti-org/luanti/pull/6900))
     * SmallJoker will test again and possibly merge after success
-* Android C++11 build fix ([https://github.com/minetest/minetest/pull/6796](https://github.com/minetest/minetest/pull/6796))
+* Android C++11 build fix ([https://github.com/luanti-org/luanti/pull/6796](https://github.com/luanti-org/luanti/pull/6796))
     * Log: [http://irc.minetest.net/minetest-dev/2018-03-10#i\_5249684](http://irc.minetest.net/minetest-dev/2018-03-10#i_5249684)
     * sfan5 and nerzhul will try to test it soon. It does not break the regular setup, so a merge is to expect soon
     * Confirmed working by Wayward\_One ([http://irc.minetest.net/minetest-dev/2018-03-10#i\_5249720](http://irc.minetest.net/minetest-dev/2018-03-10#i_5249720))
-* Autogenerated settings header ([https://github.com/minetest/minetest/pull/6728](https://github.com/minetest/minetest/pull/6728))
+* Autogenerated settings header ([https://github.com/luanti-org/luanti/pull/6728](https://github.com/luanti-org/luanti/pull/6728))
     * Log: [http://irc.minetest.net/minetest-dev/2018-03-10#i\_5249703](http://irc.minetest.net/minetest-dev/2018-03-10#i_5249703) (stub)
     * Needs attention
 
@@ -1168,7 +1168,7 @@ Arranged by: Krock
 * Definitive release date
     * absent nerzhul: “release 0.4.17 ASAP” ([http://irc.minetest.net/minetest-dev/2018-03-10#i\_5249422](http://irc.minetest.net/minetest-dev/2018-03-10#i_5249422))
 * Are there any new, important bugfixes to backport?
-* Volunteer for cherry-picking the 6 TODO (+ ^ from above) commits ([https://github.com/minetest/minetest/pull/6746](https://github.com/minetest/minetest/pull/6746))
+* Volunteer for cherry-picking the 6 TODO (+ ^ from above) commits ([https://github.com/luanti-org/luanti/pull/6746](https://github.com/luanti-org/luanti/pull/6746))
 
 2017-05-20
 ----------
@@ -1192,7 +1192,7 @@ Old business:
     deserialization part (no bench to show it atm, but i did it 2 years ago on my fork, and SQLite was improved since this date)
  * Add list_predict formspec element (#1988)
    * sofar worked on a rebase a while ago.  Close or merge a modern version?
- * New screenshots for website (web#78)  https://github.com/minetest/minetest.github.io/issues/78
+ * New screenshots for website (web#78)  https://github.com/luanti-org/luanti.github.io/issues/78
    * ShadowNinja: "good" screenshots are fairly subjective and it doesn't look like we're actually
     getting anywhere near a decision in the issue thread, therefore I propose assigning someone to choose and install new screenshots.
    * > Calinou will handle it
@@ -1200,25 +1200,25 @@ Old business:
 
 New business:
  * First, release blockers:
- * https://github.com/minetest/minetest/pull/5767 Don't add damage flash while punch texture modifier is active #5767
+ * https://github.com/luanti-org/luanti/pull/5767 Don't add damage flash while punch texture modifier is active #5767
    * > Bugfix, punted to next meeting.
- * https://github.com/minetest/minetest/issues/5782 [CSM] Disable preview mod before release #5782
+ * https://github.com/luanti-org/luanti/issues/5782 [CSM] Disable preview mod before release #5782
    * CSM disabled by default anyways since it's experimental
    * > Fixed by #5554
- * https://github.com/minetest/minetest/issues/5728 Block instadig after tool switch #5728
+ * https://github.com/luanti-org/luanti/issues/5728 Block instadig after tool switch #5728
    * > Fixed by #5785
  * nerzhul:
- * https://github.com/minetest/minetest/pull/5732 (CSM nodedefs/itemdefs read)
- * maybe close https://github.com/minetest/minetest/pull/5654
- * Single/Multiplayer tab merge https://github.com/minetest/minetest/pull/5627 (user UI experience)
+ * https://github.com/luanti-org/luanti/pull/5732 (CSM nodedefs/itemdefs read)
+ * maybe close https://github.com/luanti-org/luanti/pull/5654
+ * Single/Multiplayer tab merge https://github.com/luanti-org/luanti/pull/5627 (user UI experience)
    * > Merge with minor changes
- * Create world better experience: https://github.com/minetest/minetest/pull/5589
- * Permit to enable/disable mods on CSM  https://github.com/minetest/minetest/pull/5554 (very important)
+ * Create world better experience: https://github.com/luanti-org/luanti/pull/5589
+ * Permit to enable/disable mods on CSM  https://github.com/luanti-org/luanti/pull/5554 (very important)
    * ShadowNina: CSM is experimental, so I don't think any CSM issues should be blockers
      * nerzhul: here the problem if a user enable client side modding his experience will be affected by this preview mod, dedicated to modders)
    * > nerzhul will merge
- * https://github.com/minetest/minetest/pull/5589 (start world after creation)
- * LMDB backend (https://github.com/minetest/minetest/pull/4206)
+ * https://github.com/luanti-org/luanti/pull/5589 (start world after creation)
+ * LMDB backend (https://github.com/luanti-org/luanti/pull/4206)
    * nerzhul: Close? We already have 5 backends to maintain and we already cover all the usecases (client usage, performance usage, reliability usage)
 
 
@@ -1249,7 +1249,7 @@ Old business:
 
 
 New business:
- * New screenshots for website (web#78)  https://github.com/minetest/minetest.github.io/issues/78
+ * New screenshots for website (web#78)  https://github.com/luanti-org/luanti.github.io/issues/78
    * ShadowNinja: "good" screenshots are fairly subjective and it doesn't look like we're actually getting anywhere near a decision in the issue thread, therefore I propose assigning someone to choose and install new screenshots.
  * Fix 'alpha' property for liquid nodes (#5494)
    * > paramat testing.
@@ -1259,12 +1259,12 @@ New business:
 
 nerzhul: please look at recent PR for this meeting. Feature Freeze is in 8 days
 Here is a list to look at:
- * https://github.com/minetest/minetest/pull/5746 (cleanup content_mapblock)
- * https://github.com/minetest/minetest/pull/5732 (CSM nodedefs/itemdefs read)
- * maybe close https://github.com/minetest/minetest/pull/5654
- * Single/Multiplayer tab merge https://github.com/minetest/minetest/pull/5627 (user UI experience)
- * Create world better experience: https://github.com/minetest/minetest/pull/5589
- * Permit to enable/disable mods on CSM  https://github.com/minetest/minetest/pull/5554 (very important)
+ * https://github.com/luanti-org/luanti/pull/5746 (cleanup content_mapblock)
+ * https://github.com/luanti-org/luanti/pull/5732 (CSM nodedefs/itemdefs read)
+ * maybe close https://github.com/luanti-org/luanti/pull/5654
+ * Single/Multiplayer tab merge https://github.com/luanti-org/luanti/pull/5627 (user UI experience)
+ * Create world better experience: https://github.com/luanti-org/luanti/pull/5589
+ * Permit to enable/disable mods on CSM  https://github.com/luanti-org/luanti/pull/5554 (very important)
 
 
 ```
@@ -1304,13 +1304,13 @@ New business:
     Clean up numeric.h and split FaceFositionCache from it (#3256)
         Up-to-date and looks more-or-less ready to merge, just needs formal approval.
     <nerzhul>:
-        https://github.com/minetest/minetest/pull/5361 Background color on textarea/field/pwdfield)
-        https://github.com/minetest/minetest/pull/5355: vertical bar in text areas
-        Possible close: https://github.com/minetest/minetest/pull/5281 and https://github.com/minetest/minetest/pull/5279
-        Documentation update: https://github.com/minetest/minetest/pull/4968 close or not close ?
+        https://github.com/luanti-org/luanti/pull/5361 Background color on textarea/field/pwdfield)
+        https://github.com/luanti-org/luanti/pull/5355: vertical bar in text areas
+        Possible close: https://github.com/luanti-org/luanti/pull/5281 and https://github.com/luanti-org/luanti/pull/5279
+        Documentation update: https://github.com/luanti-org/luanti/pull/4968 close or not close ?
 
 For future meeting:
-    If finished: https://github.com/minetest/minetest/pull/5544 (on_item_use CSM)
+    If finished: https://github.com/luanti-org/luanti/pull/5544 (on_item_use CSM)
 
 
 ```
@@ -1402,5 +1402,5 @@ Add your points here. Most important comes first.
 
 Also consider:
 
-* ["One Approval" PRs](https://github.com/minetest/minetest/pulls?q=is%3Aopen+is%3Apr+label%3A%22One+approval%22) and decide on whether to merge, request changes or close.
-* ["Roadmap: needs approval" PRs](https://github.com/minetest/minetest/pulls?q=is%3Aopen+is%3Apr+label%3A%22Roadmap%3A+Needs+approval%22)
+* ["One Approval" PRs](https://github.com/luanti-org/luanti/pulls?q=is%3Aopen+is%3Apr+label%3A%22One+approval%22) and decide on whether to merge, request changes or close.
+* ["Roadmap: needs approval" PRs](https://github.com/luanti-org/luanti/pulls?q=is%3Aopen+is%3Apr+label%3A%22Roadmap%3A+Needs+approval%22)

--- a/content/engine-dev-process/meetings.md
+++ b/content/engine-dev-process/meetings.md
@@ -727,7 +727,7 @@ Also have a look at "One Approval" PRs and decide on whether to merge, request c
 
 **MTG discussion/reviews**
 
-* [Don't block fluid (water, lava) flow by flowers, mushrooms, grass and saplings](https://github.com/luanti-org/luanti_game/pull/2942)
+* [Don't block fluid (water, lava) flow by flowers, mushrooms, grass and saplings](https://github.com/luanti-org/minetest_game/pull/2942)
     * Does this break builds? Does this count as a feature? **\->** Closed as too close to a feature
 
 2021-09-04
@@ -798,8 +798,8 @@ Also have a look at "One Approval" PRs and decide on whether to merge, request c
 
 **MTG discussion/reviews**
 
-* [https://github.com/luanti-org/luanti\_game/pull/2803](https://github.com/luanti-org/luanti_game/pull/2803) Texture compression issue
-    * Based on issue [https://github.com/luanti-org/luanti\_game/issues/2801](https://github.com/luanti-org/luanti_game/issues/2801)
+* [https://github.com/luanti-org/minetest_game/pull/2803](https://github.com/luanti-org/minetest_game/pull/2803) Texture compression issue
+    * Based on issue [https://github.com/luanti-org/minetest_game/issues/2801](https://github.com/luanti-org/minetest_game/issues/2801)
     * imagefilters.cpp imageCleanTransparent() might need fixing to get white-filled opaque leaves after adding colors to the texture
     * Affected textures are whitelisted, but ExeVirus review that again
 
@@ -877,8 +877,8 @@ Logs: [http://irc.minetest.net/minetest-dev/2020-10-03#i\_5738345](http://irc.mi
 
 **MTG discussion/reviews**
 
-* Wall extension (trivial): [https://github.com/luanti-org/luanti\_game/pull/2237](https://github.com/luanti-org/luanti_game/pull/2237)
-* Craftguide: [https://github.com/luanti-org/luanti\_game/pull/2396](https://github.com/luanti-org/luanti_game/pull/2396)
+* Wall extension (trivial): [https://github.com/luanti-org/minetest_game/pull/2237](https://github.com/luanti-org/minetest_game/pull/2237)
+* Craftguide: [https://github.com/luanti-org/minetest_game/pull/2396](https://github.com/luanti-org/minetest_game/pull/2396)
 
 2020-06-06
 ----------
@@ -926,7 +926,7 @@ Most important first.
 
 **MTG discussion/reviews**
 
-* Probably 5.3.0 or later: Craft guide: [https://github.com/luanti-org/luanti\_game/pull/2396](https://github.com/luanti-org/luanti_game/pull/2396)
+* Probably 5.3.0 or later: Craft guide: [https://github.com/luanti-org/minetest_game/pull/2396](https://github.com/luanti-org/minetest_game/pull/2396)
     * Should this be added in 5.2 or not?
 
 2020-01-11
@@ -949,7 +949,7 @@ Most important first.
 
 **MTG discussion/reviews**
 
-* Craftguide from pauloue [https://github.com/luanti-org/luanti\_game/pull/2396](https://github.com/luanti-org/luanti_game/pull/2396)
+* Craftguide from pauloue [https://github.com/luanti-org/minetest_game/pull/2396](https://github.com/luanti-org/minetest_game/pull/2396)
 
 2019-08-10
 ----------
@@ -1107,7 +1107,7 @@ Arranged by: Krock
 
 **MTG discussion/reviews**
 
-* Tools: rebalance ([https://github.com/luanti-org/luanti\_game/issues/1681](https://github.com/luanti-org/luanti_game/issues/1681))
+* Tools: rebalance ([https://github.com/luanti-org/minetest_game/issues/1681](https://github.com/luanti-org/minetest_game/issues/1681))
     * Needs either a levelling system and/or special abilities for different materials to add variety
     * paramat suggests removing bronze, which is incorrectly a stronger tool than steel ([http://irc.minetest.net/minetest-dev/2018-04-07#i\_5272959](http://irc.minetest.net/minetest-dev/2018-04-07#i_5272959))
     * Future mese concept: [http://irc.minetest.net/minetest-dev/2018-04-07#i\_5273013](http://irc.minetest.net/minetest-dev/2018-04-07#i_5273013)

--- a/content/engine-dev-process/merging-core-pull-requests-to-upstream.md
+++ b/content/engine-dev-process/merging-core-pull-requests-to-upstream.md
@@ -14,15 +14,15 @@ For guidelines and rules on Git and Github, see [Git Guidelines](/Git_Guidelines
 
 Also see:
 
-* [https://github.com/minetest/minetest/blob/master/.github/CONTRIBUTING.md](https://github.com/minetest/minetest/blob/master/.github/CONTRIBUTING.md)
-* [https://github.com/minetest/minetest/blob/master/doc/direction.md](https://github.com/minetest/minetest/blob/master/doc/direction.md)
+* [https://github.com/luanti-org/luanti/blob/master/.github/CONTRIBUTING.md](https://github.com/luanti-org/luanti/blob/master/.github/CONTRIBUTING.md)
+* [https://github.com/luanti-org/luanti/blob/master/doc/direction.md](https://github.com/luanti-org/luanti/blob/master/doc/direction.md)
 
 Requirements
 ------------
 
 There are five major requirements that each pull request must fullfill in order to be mergeable to upstream Minetest.
 
-1.  It should follow a roadmap in some way, to make sure it fits the whole picture of the project. Different roadmaps and project guidance is managed in [https://github.com/minetest/minetest/blob/master/doc/direction.md](https://github.com/minetest/minetest/blob/master/doc/direction.md). A core dev can decide to review and merge something that doesn't follow direction.md if they consider it to be beneficial to the project.
+1.  It should follow a roadmap in some way, to make sure it fits the whole picture of the project. Different roadmaps and project guidance is managed in [https://github.com/luanti-org/luanti/blob/master/doc/direction.md](https://github.com/luanti-org/luanti/blob/master/doc/direction.md). A core dev can decide to review and merge something that doesn't follow direction.md if they consider it to be beneficial to the project.
 2.  It must work in the first place. Compile it and test it in game, or write mod code that uses it.
 3.  The code style must be correct. [/Code\_style\_guidelines](/Code_style_guidelines)
 4.  The internal interfaces of the code must be good, and it should be reasonably optimized, depending on how often the code is called.

--- a/content/engine-dev-process/releasing-luanti.md
+++ b/content/engine-dev-process/releasing-luanti.md
@@ -98,7 +98,7 @@ This consists of:
 
 ### Update website credits
 
-Once the credits are decided on in the previous step, update the website to be in sync with the mainmenu. Simply copy the same `credits.json` to here: [https://github.com/minetest/minetest.github.io/tree/master/\_data](https://github.com/minetest/minetest.github.io/tree/master/_data)
+Once the credits are decided on in the previous step, update the website to be in sync with the mainmenu. Simply copy the same `credits.json` to here: [https://github.com/luanti-org/luanti.github.io/tree/master/\_data](https://github.com/luanti-org/luanti.github.io/tree/master/_data)
 
 ### Update changelog
 
@@ -106,7 +106,7 @@ Changelog can be found [here](/Changelog "Changelog").
 
 ### Ensure protocol version codes have been bumped
 
-If not a patch release: ensure that `PROTOCOL_VERSION` has been increased since the last release. ([deciding discussion](https://github.com/minetest/minetest/issues/11603))
+If not a patch release: ensure that `PROTOCOL_VERSION` has been increased since the last release. ([deciding discussion](https://github.com/luanti-org/luanti/issues/11603))
 
 If formspec features have been added: ensure `LATEST_FORMSPEC_VERSION` has been increased since the last release.
 
@@ -128,7 +128,7 @@ The process with patch releases is slightly different but the script will take c
 
 ### Build Windows version
 
-As of [December 2023](https://github.com/minetest/minetest/pull/14098), we use the **mingw** artifacts of the "windows" CI workflow.
+As of [December 2023](https://github.com/luanti-org/luanti/pull/14098), we use the **mingw** artifacts of the "windows" CI workflow.
 
 *   Extract the outer ZIP file so that users only have one ZIP file to extract (should be named `luanti-5.x.x-win64.zip`)
 
@@ -149,10 +149,10 @@ _Note_: Don't cheat on this by testing in Wine, it has happened that things cras
 
 ### Upload packages to somewhere
 
-*   All official builds are hosted at Github: [https://github.com/minetest/minetest/releases](https://github.com/minetest/minetest/releases)
+*   All official builds are hosted at Github: [https://github.com/luanti-org/luanti/releases](https://github.com/luanti-org/luanti/releases)
 *   The Windows build is created by CI
     *   (see above)
-*   The macOS build is created by [Github Actions](https://github.com/minetest/minetest/actions/workflows/macos.yml)
+*   The macOS build is created by [Github Actions](https://github.com/luanti-org/luanti/actions/workflows/macos.yml)
     *   you will only be able to grab the build **after** the release has been pushed
     *   download the artifact, unpack it once, you should have a `luanti-5.x.x-osx.zip`. This is then uploaded.
 *   Android APKs are also uploaded here when they're done
@@ -180,7 +180,7 @@ Therefore, you'll generate merge commits, but this shouldn't be a problem. In th
 
 ### Tag Android deps
 
-Create a new tag [on this repo](https://github.com/minetest/minetest_android_deps/tags) with the version number of the release. This is to make it easier to figure out which state an APK was built from.
+Create a new tag [on this repo](https://github.com/luanti-org/luanti_android_deps/tags) with the version number of the release. This is to make it easier to figure out which state an APK was built from.
 
 ### Update Launchpad stable build to get Ubuntu builds for the new version
 
@@ -232,7 +232,7 @@ After releasing
 
 ### Write a release notice
 
-*   Don't forget to edit the luanti.org page ([Repo](https://github.com/minetest/minetest.github.io)).
+*   Don't forget to edit the luanti.org page ([Repo](https://github.com/luanti-org/luanti.github.io)).
     *   currently you will need to update machine readable metadata in \_data/release.yml and downloads.html itself.
 *   Post a new topic in the [News section](https://forum.luanti.org/viewforum.php?f=18) of the forum. **See [Changelog](/Changelog "Changelog").**
     *   It is customary to sticky the newest release topic and lock older ones.

--- a/content/engine-dev-process/releasing-luanti.md
+++ b/content/engine-dev-process/releasing-luanti.md
@@ -236,7 +236,7 @@ After releasing
     *   currently you will need to update machine readable metadata in \_data/release.yml and downloads.html itself.
 *   Post a new topic in the [News section](https://forum.luanti.org/viewforum.php?f=18) of the forum. **See [Changelog](/Changelog "Changelog").**
     *   It is customary to sticky the newest release topic and lock older ones.
-*   Add a new post to the [blog](https://github.com/minetest/blog/)
+*   Add a new post to the [blog](https://github.com/luanti-org/blog/)
 *   Announce the release on [Twitter](https://twitter.com/MinetestProject) and [Mastodon](https://mastodon.online/@Luanti@fosstodon.org). rubenwardy has access.
 
 ### Update wiki version template

--- a/content/engine/network-protocol.md
+++ b/content/engine/network-protocol.md
@@ -9,11 +9,11 @@ aliases:
 High-level protocol
 -------------------
 
-The high-level protocol is clearly written down and updated in [networkprotocol.h](https://github.com/minetest/minetest/blob/master/src/network/networkprotocol.h).
+The high-level protocol is clearly written down and updated in [networkprotocol.h](https://github.com/luanti-org/luanti/blob/master/src/network/networkprotocol.h).
 
-For specifics, refer to [client.cpp](https://github.com/minetest/minetest/blob/master/src/client.cpp) and [server.cpp](https://github.com/minetest/minetest/blob/master/src/server.cpp) for the sending, and [clientpackethandler.cpp](https://github.com/minetest/minetest/blob/master/src/network/clientpackethandler.cpp) and [serverpackethandler.cpp](https://github.com/minetest/minetest/blob/master/src/network/serverpackethandler.cpp) for the receiving.
+For specifics, refer to [client.cpp](https://github.com/luanti-org/luanti/blob/master/src/client.cpp) and [server.cpp](https://github.com/luanti-org/luanti/blob/master/src/server.cpp) for the sending, and [clientpackethandler.cpp](https://github.com/luanti-org/luanti/blob/master/src/network/clientpackethandler.cpp) and [serverpackethandler.cpp](https://github.com/luanti-org/luanti/blob/master/src/network/serverpackethandler.cpp) for the receiving.
 
-There is also an ascii art inside [clientiface.h](https://github.com/minetest/minetest/blob/master/src/clientiface.h) describing the protocol from a high level perspective.
+There is also an ascii art inside [clientiface.h](https://github.com/luanti-org/luanti/blob/master/src/clientiface.h) describing the protocol from a high level perspective.
 
 Actual minimum protocol version is: **24**. This corresponds to version **0.4.11**.
 
@@ -65,7 +65,7 @@ The actual SRP exchange is done in accordance with [RFC 2945](https://tools.ietf
 Low-level protocol
 ------------------
 
-References: [connection.h](https://github.com/minetest/minetest/blob/master/src/network/connection.h) [connection.cpp](https://github.com/minetest/minetest/blob/master/src/network/connection.cpp)
+References: [connection.h](https://github.com/luanti-org/luanti/blob/master/src/network/connection.h) [connection.cpp](https://github.com/luanti-org/luanti/blob/master/src/network/connection.cpp)
 
 The Luanti protocol is a small layer on top of UDP. There is a header and four packet types.
 

--- a/content/faq.md
+++ b/content/faq.md
@@ -59,7 +59,7 @@ When you boot up Luanti for the first time, it will point you to the content bro
 
 Irrlicht is a rather ancient real-time 3D rendering library. Currently Luanti uses it for rendering, managing the window, the underlying GUI, input handling, model and image format support.
 
-As it's old and mostly unmaintained, there is work on moving away from Irrlicht. Currently Luanti uses its own fork of Irrlicht called [IrrlichtMt](https://github.com/minetest/irrlicht), which is supposed to distill Irrlicht down to what Luanti actually uses, along with fixing issues that were previously out of reach. The goal is to reduce the reliance on Irrlicht in favour of SDL2 and our own rendering pipeline.
+As it's old and mostly unmaintained, there is work on moving away from Irrlicht. Currently Luanti uses its own fork of Irrlicht called [IrrlichtMt](https://github.com/luanti-org/luanti/tree/master/irr#irrlichtmt-version-19), which is supposed to distill Irrlicht down to what Luanti actually uses, along with fixing issues that were previously out of reach. The goal is to reduce the reliance on Irrlicht in favour of SDL2 and our own rendering pipeline.
 
 ### Why does the UI look so old?
 

--- a/content/faq.md
+++ b/content/faq.md
@@ -25,7 +25,7 @@ When Luanti was initially created in 2010 it intended to replicate what Minecraf
 
 ### Who created Luanti?
 
-Luanti was originally created by [Perttu "celeron55" Ahola](https://www.c55.me/). The engine is currently developed by [this random bunch of lunatics](https://github.com/orgs/minetest/people) as well as [the community](https://github.com/minetest/minetest/graphs/contributors).
+Luanti was originally created by [Perttu "celeron55" Ahola](https://www.c55.me/). The engine is currently developed by [this random bunch of lunatics](https://github.com/orgs/minetest/people) as well as [the community](https://github.com/luanti-org/luanti/graphs/contributors).
 
 ### What is Luanti written in?
 
@@ -33,11 +33,11 @@ The Luanti engine is primarily written in C++ using a [forked version of the Irr
 
 ### Can I change the code myself?
 
-[Yes.](https://github.com/minetest/minetest/) Luanti is freely licensed ([LGPL 2.1 and others](https://github.com/minetest/minetest/blob/master/LICENSE.txt)).
+[Yes.](https://github.com/luanti-org/luanti/) Luanti is freely licensed ([LGPL 2.1 and others](https://github.com/luanti-org/luanti/blob/master/LICENSE.txt)).
 
 ### When will the next version of Luanti be released?
 
-Check the [GitHub milestones](https://github.com/minetest/minetest/milestones) for a good idea of how far along the next version is.
+Check the [GitHub milestones](https://github.com/luanti-org/luanti/milestones) for a good idea of how far along the next version is.
 
 #### Why did the version change from 0.4.17.1 to 5.0.0?
 
@@ -69,11 +69,11 @@ It is certainly possible to improve the UI, and some games style their GUI wonde
 
 ### The main menu sucks!
 
-[We're working on it.](https://github.com/minetest/minetest/issues/6733)
+[We're working on it.](https://github.com/luanti-org/luanti/issues/6733)
 
 ### Is Luanti multi-threaded?
 
-Yes. Luanti's client and server run in different threads. The server also runs map generation in worker threads, although this is limited to a single thread currently due to issues (but [can be changed in settings](https://github.com/minetest/minetest/blob/eea2a97/minetest.conf.example#L2973-L2984)). The client runs mesh generation in worker threads. As of 5.7.0, mapblock rendering is done in parallel on several threads.
+Yes. Luanti's client and server run in different threads. The server also runs map generation in worker threads, although this is limited to a single thread currently due to issues (but [can be changed in settings](https://github.com/luanti-org/luanti/blob/eea2a97/minetest.conf.example#L2973-L2984)). The client runs mesh generation in worker threads. As of 5.7.0, mapblock rendering is done in parallel on several threads.
 
 It's rare for games to be heavily concurrent as it's not needed for smaller games - it's usually only found in MMOs. It's a lot harder to write multi-threaded gameplay logic, which is in conflict with Luanti's aim to be an easy-to-use content creation platform. There is an API for mods to run tasks in a worker thread, however.
 
@@ -84,7 +84,7 @@ The name "Luanti" is a play on words from the Finnish word "Luonti" meaning crea
 ### What is "Minetest"?
 It is the old name for Luanti, which is slowly being replaced with the new name but will realistically never fully disappear.
 
-The origin of the old name was due to it starting as an experiment (a **test**, if you will) to replicate **Mine**craft Alpha all the way back in 2010. The name stuck, and [no one could agree](https://forum.luanti.org/viewtopic.php?f=5&t=17133) [on a new one](https://github.com/minetest/minetest/issues/13510). [Until we actually did](https://blog.luanti.org/2024/10/13/Introducing-Our-New-Name/).
+The origin of the old name was due to it starting as an experiment (a **test**, if you will) to replicate **Mine**craft Alpha all the way back in 2010. The name stuck, and [no one could agree](https://forum.luanti.org/viewtopic.php?f=5&t=17133) [on a new one](https://github.com/luanti-org/luanti/issues/13510). [Until we actually did](https://blog.luanti.org/2024/10/13/Introducing-Our-New-Name/).
 
 ### Can you add support for iOS?
 
@@ -158,7 +158,7 @@ Minetest Game is not designed with a story or goal in mind. It is simply a sandb
 
 ### You should add \[insert feature here\] to Minetest Game!
 
-Minetest Game is [currently in maintenance-only mode](https://github.com/minetest/minetest_game/issues/2710). New gameplay features are not being considered and should be added yourself as a mod.
+Minetest Game is [currently in maintenance-only mode](https://github.com/luanti-org/luanti_game/issues/2710). New gameplay features are not being considered and should be added yourself as a mod.
 
 ### How does \[insert item or block here\] work? How do I craft it?
 
@@ -196,7 +196,7 @@ Yes. It is recommended to use an external program to bind them, as the current e
 
 ### Why can't I change settings in the pause screen?
 
-Many settings require the game to reload anyway, but otherwise there simply isn't a menu implemented to do it. [Contributions welcome](https://github.com/minetest/minetest/pulls).
+Many settings require the game to reload anyway, but otherwise there simply isn't a menu implemented to do it. [Contributions welcome](https://github.com/luanti-org/luanti/pulls).
 
 ### How big is the map?
 
@@ -220,7 +220,7 @@ Minetest Game uses pre-1.8 Minecraft skins (64x32). These support regular body t
 
 If you play Minetest Game, you can build a [bed](https://wiki.luanti.org/Bed "Bed") and sleep at night. On your next life, you will spawn on the bed.
 
-Otherwise, you set your spawn point for _all_ worlds using `static_spawnpoint = (x,y,z)` in your [`minetest.conf`](https://github.com/minetest/minetest/blob/master/minetest.conf.example) file.
+Otherwise, you set your spawn point for _all_ worlds using `static_spawnpoint = (x,y,z)` in your [`minetest.conf`](https://github.com/luanti-org/luanti/blob/master/minetest.conf.example) file.
 
 ### How do I make the world flat?
 
@@ -256,7 +256,7 @@ In Minetest Game, you can avoid getting lost again if use `/sethome` at home to 
 
 ### How do I generate a map of my world?
 
-To generate a top-down image of your world you can use [`minetestmapper`](https://github.com/minetest/minetestmapper), and to generate an isometric view of a part of the world you can use [`maprenderer`](https://github.com/minetest-go/maprenderer).
+To generate a top-down image of your world you can use [`minetestmapper`](https://github.com/luanti-org/luantimapper), and to generate an isometric view of a part of the world you can use [`maprenderer`](https://github.com/minetest-go/maprenderer).
 
 ### Can I use WorldPainter with Luanti?
 
@@ -288,7 +288,7 @@ Luanti uses the [Lua language](https://www.lua.org/) for games and mods. It is s
 
 ### How can I learn to make games and mods?
 
-We recommend the [Luanti Modding Book](https://rubenwardy.com/minetest_modding_book/en/index.html) to start. For more experienced users there is the [Lua API reference](https://github.com/minetest/minetest/blob/master/doc/lua_api.md) available in the Luanti source tree, which is also available [in a pretty HTML version](https://api.luanti.org/).
+We recommend the [Luanti Modding Book](https://rubenwardy.com/minetest_modding_book/en/index.html) to start. For more experienced users there is the [Lua API reference](https://github.com/luanti-org/luanti/blob/master/doc/lua_api.md) available in the Luanti source tree, which is also available [in a pretty HTML version](https://api.luanti.org/).
 
 If you need further help feel free to ask any questions in the forums or in any of the discussion channels (e.g. IRC, Discord...).
 
@@ -310,11 +310,11 @@ Lua can easily outperform a bridge to Java in most cases. If you really need to 
 
 ### What is the Luanti API?
 
-The Luanti API gives you access to everything the engine currently has to offer. You can find the latest API reference [here](https://github.com/minetest/minetest/blob/master/doc/lua_api.md). A ReadTheDocs version can be read [here](https://api.luanti.org/).
+The Luanti API gives you access to everything the engine currently has to offer. You can find the latest API reference [here](https://github.com/luanti-org/luanti/blob/master/doc/lua_api.md). A ReadTheDocs version can be read [here](https://api.luanti.org/).
 
 ### Can mods overwrite the engine?
 
-Luanti mods must use the engine-provided API. Unlike Minecraft, Luanti mods cannot change the engine. If you think the engine is missing a feature, consider [opening an issue](https://github.com/minetest/minetest/issues) or [write the feature yourself](https://github.com/minetest/minetest/pulls).
+Luanti mods must use the engine-provided API. Unlike Minecraft, Luanti mods cannot change the engine. If you think the engine is missing a feature, consider [opening an issue](https://github.com/luanti-org/luanti/issues) or [write the feature yourself](https://github.com/luanti-org/luanti/pulls).
 
 ### What is a formspec?
 
@@ -348,7 +348,7 @@ _See [Troubleshooting#Error messages without crashes](https://wiki.luanti.org/Tr
 
 ### Why can't I make other keybinds?
 
-This is a missing feature. [Contributions welcome](https://github.com/minetest/minetest/pulls).
+This is a missing feature. [Contributions welcome](https://github.com/luanti-org/luanti/pulls).
 
 ### How do I make models for my mods?
 
@@ -364,4 +364,4 @@ Yes, but this is not officially supported in the engine, you will need to mainta
 
 ### Can I sell games I make with Luanti?
 
-As long as you comply with [the license](https://github.com/minetest/minetest/blob/master/LICENSE.txt), yes. For the engine, you will need to publish the source code to any modifications you've made to it. If you use others' mods in the game then make sure you comply with their license terms and that they don't contain non-free assets that prevent commercial usage.
+As long as you comply with [the license](https://github.com/luanti-org/luanti/blob/master/LICENSE.txt), yes. For the engine, you will need to publish the source code to any modifications you've made to it. If you use others' mods in the game then make sure you comply with their license terms and that they don't contain non-free assets that prevent commercial usage.

--- a/content/faq.md
+++ b/content/faq.md
@@ -158,7 +158,7 @@ Minetest Game is not designed with a story or goal in mind. It is simply a sandb
 
 ### You should add \[insert feature here\] to Minetest Game!
 
-Minetest Game is [currently in maintenance-only mode](https://github.com/luanti-org/luanti_game/issues/2710). New gameplay features are not being considered and should be added yourself as a mod.
+Minetest Game is [currently in maintenance-only mode](https://github.com/luanti-org/minetest_game/issues/2710). New gameplay features are not being considered and should be added yourself as a mod.
 
 ### How does \[insert item or block here\] work? How do I craft it?
 

--- a/content/getting-started.md
+++ b/content/getting-started.md
@@ -43,7 +43,7 @@ If you are on a distribution with up to date enough repositories (e.g. Arch), yo
 
 Otherwise it is recommended to obtain Luanti through other means, such as the [Flatpak package](https://flathub.org/apps/details/net.minetest.Minetest). For Ubuntu and similar, there is the [Luanti PPA](https://launchpad.net/~minetestdevs/+archive/ubuntu/stable).
 
-If all else fails, you can build from source by [cloning the engine repository](https://github.com/minetest/minetest) and [following the build instructions](https://github.com/minetest/minetest/blob/master/doc/compiling/linux.md).
+If all else fails, you can build from source by [cloning the engine repository](https://github.com/luanti-org/luanti) and [following the build instructions](https://github.com/luanti-org/luanti/blob/master/doc/compiling/linux.md).
 
 Playing
 -------

--- a/content/list-of-hardcoded-features.md
+++ b/content/list-of-hardcoded-features.md
@@ -12,9 +12,9 @@ Gameplay
 
 ### Health and damage
 
-* The fall damage calculation formula (issue: [#10348](https://github.com/minetest/minetest/pull/10348))
+* The fall damage calculation formula (issue: [#10348](https://github.com/luanti-org/luanti/pull/10348))
 * Nodes that deal direct damage do so always once per second (with `damage_per_second`); no other time interval is possible
-* How breath works in general (issue: [#8042](https://github.com/minetest/minetest/pull/8042))
+* How breath works in general (issue: [#8042](https://github.com/luanti-org/luanti/pull/8042))
 * You lose breath or take drowning damage every 2 seconds, and you regain breath every 0.5 seconds
 * The amount of time the `damage_texture_modifier` is applied when an object takes damage is hardcoded
 
@@ -24,12 +24,12 @@ Gameplay
     * You can change the parameters, but not the formula itself
 * The formula that determines how much your tool will be worn
     * You can change the parameters, but not the formula itself
-* All items can point (issue: [#6651](https://github.com/minetest/minetest/pull/6651))
+* All items can point (issue: [#6651](https://github.com/luanti-org/luanti/pull/6651))
     * `range=0` does not work as you can point when you're inside a node
 
 ### Players
 
-* All players have **all camera modes**, always. They can not be disabled or forced (issue: [#12855](https://github.com/minetest/minetest/issues/12855))
+* All players have **all camera modes**, always. They can not be disabled or forced (issue: [#12855](https://github.com/luanti-org/luanti/issues/12855))
 
 Graphics
 --------
@@ -55,7 +55,7 @@ HUD
 
 ### Formspecs
 
-* No or incomplete styling/theming/customization for ([#8744](https://github.com/minetest/minetest/issues/8744)):
+* No or incomplete styling/theming/customization for ([#8744](https://github.com/luanti-org/luanti/issues/8744)):
     * Scrollbars
     * Drop-down lists
     * Highlight color of selected text

--- a/content/luanti-schematic-file-format.md
+++ b/content/luanti-schematic-file-format.md
@@ -80,7 +80,7 @@ Probability values in `param1` are encoded in unsigned 8 bits. They are indexed 
 Official definition
 -------------------
 
-The official definition of version 4 of this file format follows and has been copied from [/src/mapgen/mg\_schematic.h](https://github.com/minetest/minetest/blob/5.1.0/src/mapgen/mg_schematic.h) in the source code of version 5.1.0.
+The official definition of version 4 of this file format follows and has been copied from [/src/mapgen/mg\_schematic.h](https://github.com/luanti-org/luanti/blob/5.1.0/src/mapgen/mg_schematic.h) in the source code of version 5.1.0.
 
 ```
 All values are stored in big-endian byte order.
@@ -110,8 +110,8 @@ For each node in schematic:
 ```
 
 
-* Source code 5.1.0: [/src/mapgen/mg\_schematic.h](https://github.com/minetest/minetest/blob/5.1.0/src/mapgen/mg_schematic.h)
-* Source code bleeding edge: [/src/mapgen/mg\_schematic.h](https://github.com/minetest/minetest/blob/master/src/mapgen/mg_schematic.h)
+* Source code 5.1.0: [/src/mapgen/mg\_schematic.h](https://github.com/luanti-org/luanti/blob/5.1.0/src/mapgen/mg_schematic.h)
+* Source code bleeding edge: [/src/mapgen/mg\_schematic.h](https://github.com/luanti-org/luanti/blob/master/src/mapgen/mg_schematic.h)
 
 Version changes
 ---------------

--- a/content/mapgen/_index.md
+++ b/content/mapgen/_index.md
@@ -32,7 +32,7 @@ All map generators use so-called "mapgen aliases". These are node aliases define
 
 All map generators have biomes. In all map generators except `v6`, these biomes are defined by games and mods using the Biome API. If no biomes are defined, the result will be a stone-only landscape. The `v6` map generator is special because its biomes are completely predefined and can't be changed trivially.
 
-All map generators allow configuration in the advanced settings. A list of all map generator settings can also be found in [minetest.conf.example](https://github.com/minetest/minetest/blob/master/minetest.conf.example).
+All map generators allow configuration in the advanced settings. A list of all map generator settings can also be found in [minetest.conf.example](https://github.com/luanti-org/luanti/blob/master/minetest.conf.example).
 
 ### Gallery
 

--- a/content/mapgen/features.md
+++ b/content/mapgen/features.md
@@ -9,7 +9,7 @@ aliases:
 This page shows the various special features which [map generators](/mapgen "Map generator") have and explains how to use them.
 
 {{< notice note >}}
-This page doesn't list all available mapgen features. For a full reference, search for `mg_flags` and `mg*_spflags` in [minetest.conf.example](https://github.com/minetest/minetest/blob/master/minetest.conf.example) instead.
+This page doesn't list all available mapgen features. For a full reference, search for `mg_flags` and `mg*_spflags` in [minetest.conf.example](https://github.com/luanti-org/luanti/blob/master/minetest.conf.example) instead.
 {{< /notice >}}
 
 ## Features shared between all mapgens except singlenode

--- a/content/minetest-conf.md
+++ b/content/minetest-conf.md
@@ -11,7 +11,7 @@ aliases:
 
 **minetest.conf** is the configuration file used for numerous purposes. This file is read every time the game starts and is always created/modified when the menu quits.
 
-A file called [minetest.conf.example](https://github.com/minetest/minetest/blob/master/minetest.conf.example) is provided as an example. See that file for a more complete list of options.
+A file called [minetest.conf.example](https://github.com/luanti-org/luanti/blob/master/minetest.conf.example) is provided as an example. See that file for a more complete list of options.
 
 Location
 --------

--- a/content/minetest-conf.md
+++ b/content/minetest-conf.md
@@ -35,7 +35,7 @@ In `minetest.conf`, you can configure most (but not all) keys, but a few more ke
 A few things to note:
 
 * Controls are written in the format `keymap_<action name> = <key name>`, e.g. `keymap_forward = KEY_KEY_W`
-* The list of possible controls (value right of the equals sign) can be seen in [\[1\]](https://github.com/minetest/irrlicht/blob/master/include/Keycodes.h). If your key isn't listed there, try writing the literal character
+* The list of possible controls (value right of the equals sign) can be seen in [\[1\]](https://github.com/luanti-org/luanti/blob/master/irr/include/Keycodes.h). If your key isn't listed there, try writing the literal character
 * To disable a control completely, leave the part right of the equals sign empty, e.g. `keymap_toggle_debug =`
 
 See [Controls](https://wiki.luanti.org/Controls "Controls") for a list of controls and their setting name (if available).

--- a/content/mobile/_index.md
+++ b/content/mobile/_index.md
@@ -31,5 +31,5 @@ You can also play Luanti on Linux phones. Starting with version 5.9.0[^2], Luant
 
 There is no iOS support due to legal uncertainties and lack of developer time. While the "MultiCraft" fork of Luanti supports iOS, it contains advertising and is still based on the outdated engine version 5.4.1, so it isn't recommended.
 
-[^1]: See PR [#14542](https://github.com/minetest/minetest/pull/14542) and its various predecessors.
-[^2]: See PRs [#14075](https://github.com/minetest/minetest/pull/14075) and [#14400](https://github.com/minetest/minetest/pull/14400).
+[^1]: See PR [#14542](https://github.com/luanti-org/luanti/pull/14542) and its various predecessors.
+[^2]: See PRs [#14075](https://github.com/luanti-org/luanti/pull/14075) and [#14400](https://github.com/luanti-org/luanti/pull/14400).

--- a/content/modding-intro.md
+++ b/content/modding-intro.md
@@ -22,7 +22,7 @@ It is recommended you start here, even if you are already apt at programming, to
 
 ### Lua API Reference
 
-The official Lua API documentation is `lua_api.md`. It's available as [markdown](https://github.com/minetest/minetest/blob/master/doc/lua_api.md) or [HTML](https://api.minetest.net/). You can find the plaintext version in your Luanti installation, in the `doc` directory.
+The official Lua API documentation is `lua_api.md`. It's available as [markdown](https://github.com/luanti-org/luanti/blob/master/doc/lua_api.md) or [HTML](https://api.minetest.net/). You can find the plaintext version in your Luanti installation, in the `doc` directory.
 
 This is a concise description of the entire API, explaining functions, data structures, registration templates & more. The core developers of Luanti maintain it, changes going through a quality control process.
 
@@ -30,7 +30,7 @@ Any functions not listed here are subject to change and not guaranteed to be com
 
 ### The Minetest-Docs Project
 
-A work-in-progress project is underway to create new, more detailed, documentation. They can be read from its [GitHub repo](https://github.com/minetest/minetest_docs/), contributions are greatly appreciated.
+A work-in-progress project is underway to create new, more detailed, documentation. They can be read from its [GitHub repo](https://github.com/luanti-org/luanti_docs/), contributions are greatly appreciated.
 
 Useful tools
 ------------

--- a/content/modding-intro.md
+++ b/content/modding-intro.md
@@ -28,9 +28,9 @@ This is a concise description of the entire API, explaining functions, data stru
 
 Any functions not listed here are subject to change and not guaranteed to be compatible across versions, though usually they are.
 
-### The Minetest-Docs Project
+### The minetest_docs Project
 
-A work-in-progress project is underway to create new, more detailed, documentation. They can be read from its [GitHub repo](https://github.com/luanti-org/luanti_docs/), contributions are greatly appreciated.
+minetest_docs was a project to create new, more detailed documentation. The final contents from the project can currently be found under the [/docs/](/docs/) directory here.
 
 Useful tools
 ------------

--- a/content/old-changelog.md
+++ b/content/old-changelog.md
@@ -205,7 +205,7 @@ Backported release containing only bug fixes and small features. 0.4.17 was rele
 
 * Introducing Client-Side modding (CSM for the initiated). You can now have local mods to read various client data and handle different client events. This new modding step is very secure, you don't have access to all standard Lua API, just a subset, to protect your computers. Mods should be installed in @user\_path@/clientmods.
 * You will also have access to Client side commands, starting with a dot.
-* If you want to know more about CSM API, please look at [Client Side Modding documentation](https://github.com/minetest/minetest/blob/master/doc/client_lua_api.md)
+* If you want to know more about CSM API, please look at [Client Side Modding documentation](https://github.com/luanti-org/luanti/blob/master/doc/client_lua_api.md)
 * Added by nerzhul, red-001, bigfoot547, Dumbeldor and paly2.
 
 ### Server Modding

--- a/content/player-physics.md
+++ b/content/player-physics.md
@@ -38,7 +38,7 @@ The idea is to add functionality to the Lua API by allowing to set modifiers (li
 
 This solution has strong community support, but sadly, it did not succeed yet.
 
-[https://github.com/minetest/minetest/pull/7269](https://github.com/minetest/minetest/pull/7269)
+[https://github.com/luanti-org/luanti/pull/7269](https://github.com/luanti-org/luanti/pull/7269)
 
 So we’re currently stuck with mod-based solutions, sadly.
 

--- a/content/reporting-bugs.md
+++ b/content/reporting-bugs.md
@@ -16,7 +16,7 @@ Luanti is never finished, it is constantly a work in progress. Thus all bug repo
 A bug might already be reported or even fixed by the time you are having problems. Please check the following sources for solution prior reporting:
 
 * [Newest Luanti version](https://www.minetest.net/downloads/) - are you using the most recent one?
-* [GitHub issue tracker](https://github.com/minetest/minetest/issues?q=is%3Aissue)
+* [GitHub issue tracker](https://github.com/luanti-org/luanti/issues?q=is%3Aissue)
 * [Libera IRC (English)](https://kiwiirc.com/nextclient/irc.libera.chat:+6697/#minetest) (answers might take a while)
 * [Luanti Forums: 'Problems'](https://forum.minetest.net/viewforum.php?f=6)
 

--- a/content/schematic.md
+++ b/content/schematic.md
@@ -46,7 +46,7 @@ The data list is ordered in z, y, x. Than means for a 3x3x3 box it will be a lis
 * The next 9 are the same pattern one node toward the red block,
 * And finally the next 9 are the same pattern starting at the red block
 
-Each MapNode holds the node name and the probability to appear. See [Schematic specifier in lua_api.md](https://github.com/minetest/minetest/blob/master/doc/lua_api.md#schematic-specifier) for more details.
+Each MapNode holds the node name and the probability to appear. See [Schematic specifier in lua_api.md](https://github.com/luanti-org/luanti/blob/master/doc/lua_api.md#schematic-specifier) for more details.
 
 A minimal table for a 3x3 bush sample:
 

--- a/content/setting-up-a-server.md
+++ b/content/setting-up-a-server.md
@@ -94,7 +94,7 @@ Usually your Linux distribution of choice will have `luantiserver` in its offici
 
 - **Building from source**: Build Luanti from source with `-DBUILD_CLIENT=0 -DBUILD_SERVER=1`. For more information see [Compiling a headless Linux server](/compiling-a-headless-linux-server/).
 
-- **Docker**: There also exist ready made Docker images for `luantiserver`, such as [the Dockerfile in the Luanti source tree](https://github.com/minetest/minetest/blob/master/Dockerfile) or [Warr1024's Docker image](https://hub.docker.com/r/warr1024/minetestserver).
+- **Docker**: There also exist ready made Docker images for `luantiserver`, such as [the Dockerfile in the Luanti source tree](https://github.com/luanti-org/luanti/blob/master/Dockerfile) or [Warr1024's Docker image](https://hub.docker.com/r/warr1024/minetestserver).
 
 ### Windows
 The regular Windows builds provided on the download page work fine, running it as `luanti.exe --server` to access the server portion of it.
@@ -225,7 +225,7 @@ For more mods useful to server administration, see the [Server Moderation and To
 ## Managing your server
 
 ### Server Configuration
-For a detailed explanation of the server configuration file, see [minetest.conf](https://github.com/minetest/minetest/blob/master/minetest.conf.example).
+For a detailed explanation of the server configuration file, see [minetest.conf](https://github.com/luanti-org/luanti/blob/master/minetest.conf.example).
 
 You may also want to consider to use a different [database backend](/database-backends) for your world.
 

--- a/content/sneaking.md
+++ b/content/sneaking.md
@@ -93,7 +93,7 @@ Sneaking used to be very buggy, but it has improved over time.
 
 ### Old bug: Avoiding fall damage
 
-Up to version 0.4.15, you don't suffer any fall damage if you fall on a normal block's edge or on a slab or snow or on some other non-cubic shapes while holding down the sneak key. This bug is known as [issue 329](https://github.com/minetest/minetest/issues/329) and is fixed since version 0.4.16.
+Up to version 0.4.15, you don't suffer any fall damage if you fall on a normal block's edge or on a slab or snow or on some other non-cubic shapes while holding down the sneak key. This bug is known as [issue 329](https://github.com/luanti-org/luanti/issues/329) and is fixed since version 0.4.16.
 
 ### The Sneak Glitch was a bug
 

--- a/content/terminology.md
+++ b/content/terminology.md
@@ -13,11 +13,11 @@ This page contains a hopefully complete list of terminology related to Luanti.
 -   **Luanti**: The game engine whose wiki you are on right now, generally refers to the engine.
 -   **Minetest**: The former name of Luanti
 -   **IrrlichtMt** / **Irrlicht**[^1]: The name of Luanti's 3D rendering library. It was forked by the Luanti developers from the original [Irrlicht](https://irrlicht.sourceforge.io/), which is ancient and poorly maintained nowadays.
-    -   IrrlichtMt has been merged into the Luanti repository as the [`irr/`](https://github.com/minetest/minetest/tree/master/irr) directory.
+    -   IrrlichtMt has been merged into the Luanti repository as the [`irr/`](https://github.com/luanti-org/luanti/tree/master/irr) directory.
 -   [**Game**](https://wiki.luanti.org/Games): A collection of mods and some additional metadata, which can be selected from the main menu. Not to be confused with Modpack which is a pack of mods selectable like regular mods.
     -   Previously were referred to as **Subgames**, but this term is outdated. Please update any references to it as such.
 -   [**Minetest Game**](http://wiki.minetest.net/Games/Minetest%20Game) (abbreviated MTG): The name of the game that used to be shipped with Luanti by default.
-    -   [minetest_game](https://github.com/minetest/minetest_game): Repository name of Minetest Game and technical name of the game.
+    -   [minetest_game](https://github.com/luanti-org/luanti_game): Repository name of Minetest Game and technical name of the game.
 -   [**Mods**](https://wiki.luanti.org/Mods) : What all games consist of, or can be added on top of an existing game. They are written in Lua using Luanti's modding API.
     -   Sometimes abbreviated SSM, Server-Side Mod to make the distinction that regular Luanti mods run on the server as compared to CSMs which run on the client.
 -   **Client-Side Mod** (abbreviated **CSM**): An experimental API allowing for the client itself to run Lua code.
@@ -28,7 +28,7 @@ This page contains a hopefully complete list of terminology related to Luanti.
 -   **Server**: The program that manages and distributes mod, texture and sound data to the players. It also does all of the mod initiation.
 -   **Client**: The program that the player uses to connect to singleplayer or multiplayer games. Handles the rendering of the world.
     -   In singleplayer, the client will start a server in the background restricted to the *singleplayer* user which will then join it, acting both as a client and a server in that case.
--   **[minetest.conf](https://wiki.luanti.org/Minetest.conf)**: A file in the root directory of Luanti's user directory which contains configuration settings for Luanti. A list of the settings can be found in the main menu's "All settings" menu or in [**minetest.conf.example**](https://github.com/minetest/minetest/blob/master/minetest.conf.example).
+-   **[minetest.conf](https://wiki.luanti.org/Minetest.conf)**: A file in the root directory of Luanti's user directory which contains configuration settings for Luanti. A list of the settings can be found in the main menu's "All settings" menu or in [**minetest.conf.example**](https://github.com/luanti-org/luanti/blob/master/minetest.conf.example).
 
 ## In-game Content
 
@@ -58,7 +58,7 @@ This page contains a hopefully complete list of terminology related to Luanti.
 
 -   **Lua**: A simple, minimal and fast programming language which is used for Luanti's API.
 -   **Modding API**/**Lua API**/**Luanti API**: a selection of functions and values, used by mod files to modify, extend or add features and blocks. API stands for **A**pplication **P**rogramming **I**nterface.
--   [**lua_api.md**](https://github.com/minetest/minetest/blob/master/doc/lua_api.md): A file in the `doc/` directory that contains the full reference of the Lua API. The same content is also available in [HTML format](https://api.luanti.org/).
+-   [**lua_api.md**](https://github.com/luanti-org/luanti/blob/master/doc/lua_api.md): A file in the `doc/` directory that contains the full reference of the Lua API. The same content is also available in [HTML format](https://api.luanti.org/).
 
 ## Notes
 

--- a/content/terminology.md
+++ b/content/terminology.md
@@ -17,7 +17,7 @@ This page contains a hopefully complete list of terminology related to Luanti.
 -   [**Game**](https://wiki.luanti.org/Games): A collection of mods and some additional metadata, which can be selected from the main menu. Not to be confused with Modpack which is a pack of mods selectable like regular mods.
     -   Previously were referred to as **Subgames**, but this term is outdated. Please update any references to it as such.
 -   [**Minetest Game**](http://wiki.minetest.net/Games/Minetest%20Game) (abbreviated MTG): The name of the game that used to be shipped with Luanti by default.
-    -   [minetest_game](https://github.com/luanti-org/luanti_game): Repository name of Minetest Game and technical name of the game.
+    -   [minetest_game](https://github.com/luanti-org/minetest_game): Repository name of Minetest Game and technical name of the game.
 -   [**Mods**](https://wiki.luanti.org/Mods) : What all games consist of, or can be added on top of an existing game. They are written in Lua using Luanti's modding API.
     -   Sometimes abbreviated SSM, Server-Side Mod to make the distinction that regular Luanti mods run on the server as compared to CSMs which run on the client.
 -   **Client-Side Mod** (abbreviated **CSM**): An experimental API allowing for the client itself to run Lua code.

--- a/content/textures.md
+++ b/content/textures.md
@@ -17,7 +17,7 @@ When run with no arguments `optipng` optimizes completely losslessly (no color, 
 * **`-o7 -zm1-9`**: Sets both optipng and zlib's optimization/compression levels to the highest available. Will take significantly longer to optimise but can further reduce the file size.
 * **`-nc`**: Disables color type reduction. **This is necessary if you have color data you want to preserve in transparent pixels, such as ones in leaf textures.**
 
-A general-purpose script for optimizing images as aggressively as possible without losing color information can be found in Minetest Game: [optimize_textures.sh](https://github.com/minetest/minetest_game/blob/master/utils/optimize_textures.sh)
+A general-purpose script for optimizing images as aggressively as possible without losing color information can be found in Minetest Game: [optimize_textures.sh](https://github.com/luanti-org/luanti_game/blob/master/utils/optimize_textures.sh)
 
 For lossy optimisation of PNG files, there is `pngquant`. It will throw away (hopefully unnoticeable) colour data and replace it with dithering. This is useful for larger images (e.g. game backgrounds) where the loss of colour data isn't noticeable, but the filesize is substantially smaller.
 

--- a/content/textures.md
+++ b/content/textures.md
@@ -17,7 +17,7 @@ When run with no arguments `optipng` optimizes completely losslessly (no color, 
 * **`-o7 -zm1-9`**: Sets both optipng and zlib's optimization/compression levels to the highest available. Will take significantly longer to optimise but can further reduce the file size.
 * **`-nc`**: Disables color type reduction. **This is necessary if you have color data you want to preserve in transparent pixels, such as ones in leaf textures.**
 
-A general-purpose script for optimizing images as aggressively as possible without losing color information can be found in Minetest Game: [optimize_textures.sh](https://github.com/luanti-org/luanti_game/blob/master/utils/optimize_textures.sh)
+A general-purpose script for optimizing images as aggressively as possible without losing color information can be found in Minetest Game: [optimize_textures.sh](https://github.com/luanti-org/minetest_game/blob/master/utils/optimize_textures.sh)
 
 For lossy optimisation of PNG files, there is `pngquant`. It will throw away (hopefully unnoticeable) colour data and replace it with dithering. This is useful for larger images (e.g. game backgrounds) where the loss of colour data isn't noticeable, but the filesize is substantially smaller.
 

--- a/content/translation/_index.md
+++ b/content/translation/_index.md
@@ -50,7 +50,7 @@ Luanti detects the current language by inspecting the `LANG` environment variabl
 
 The available translations are found in source form in the `po/` directory. The `cmake` detects them, and they are built as part of the build process.
 
-The main translation file must be updated now and then using the [this script](https://github.com/minetest/minetest/blob/master/builtin/mainmenu/settings/generate_from_settingtypes.lua) (configuration) and [this one](https://github.com/minetest/minetest/blob/master/util/updatepo.sh) (C++ and Lua translations). Submit a PR after running the generator or poke a core dev to update the translations when it's needed. Note that builtin translations are handled separately, see the maintenance notes below.
+The main translation file must be updated now and then using the [this script](https://github.com/luanti-org/luanti/blob/master/builtin/mainmenu/settings/generate_from_settingtypes.lua) (configuration) and [this one](https://github.com/luanti-org/luanti/blob/master/util/updatepo.sh) (C++ and Lua translations). Submit a PR after running the generator or poke a core dev to update the translations when it's needed. Note that builtin translations are handled separately, see the maintenance notes below.
 
 Maintaining engine translations
 -------------------------------
@@ -99,7 +99,7 @@ Add weblate as remote: `git remote add weblate [https://hosted.weblate.org/git/m
 8.  If _required/desired_, do these: (`--author="updatepo.sh <script@mt>"` should be used when committing changes made by the scripts)
     1.  Update `minetest.conf.example` and the dummy `*.cpp` translation file and commit. Do this by uncommenting the lines at the end of builtin/mainmenu/settings/init.lua
     2.  Run `util/updatepo.sh`, and commit. Note that it creates lots of unnecessary changes, and enlarges repository size disproportionately, therefore run it even less often.
-9.  Push to the [GitHub repo](https://github.com/minetest/minetest) with e.g. `git push origin HEAD:master`
+9.  Push to the [GitHub repo](https://github.com/luanti-org/luanti) with e.g. `git push origin HEAD:master`
 10.  Reset the Weblate remote ("Reset" button), rebase it to match now current master, and unlock it. If pushed commits do not yet show up in Weblate you may have to press the "Pull" button.
 
 ### Server-side builtin translations (`minetest.get_translator`)
@@ -122,6 +122,6 @@ Untranslatable texts
 
 Please note: A couple of things in Luanti can **not** be translated yet:
 
-* Setting help texts for settings of games and mods (`settingtypes.txt`) ([#9070](https://github.com/minetest/minetest/issues/9070))
+* Setting help texts for settings of games and mods (`settingtypes.txt`) ([#9070](https://github.com/luanti-org/luanti/issues/9070))
 * Drop-down list entries in Luanti settings
-* Description of mods, modpacks, games and texture packs ([#9071](https://github.com/minetest/minetest/issues/9071))
+* Description of mods, modpacks, games and texture packs ([#9071](https://github.com/luanti-org/luanti/issues/9071))

--- a/content/translation/mods-and-games.md
+++ b/content/translation/mods-and-games.md
@@ -131,7 +131,7 @@ As a mod or game developer, if you want to implement translation support, please
 
 We highly recommend you use PO instead of TR, if you can.
 
-If you’re stuck with TR, the [modtools](https://github.com/minetest/modtools) contain a an extremely useful tool that can automatically generate and update TR files for mods.
+If you’re stuck with TR, the [modtools](https://github.com/luanti-org/modtools) contain a an extremely useful tool that can automatically generate and update TR files for mods.
 
 ### Online translation
 

--- a/content/worlds.md
+++ b/content/worlds.md
@@ -27,7 +27,7 @@ The files such as `env_meta.txt` **must** be in the root of the world’s folder
 World directory content
 -----------------------
 
-See [world\_format.md](https://github.com/minetest/minetest/blob/master/doc/world_format.md) in the Luanti source tree.
+See [world\_format.md](https://github.com/luanti-org/luanti/blob/master/doc/world_format.md) in the Luanti source tree.
 
 Schem file Creation / Import
 ----------------------------


### PR DESCRIPTION
Did a full find-and-replace on all the current contents, only occurrences left of `github.com/minetest/` reference old PRs in the archived IrrlichtMt repo and the old .x exporter, both of which are still in the old organisation.