### PR TITLE
Add info about Windows compilation

### DIFF
--- a/content/compiling/android.md
+++ b/content/compiling/android.md
@@ -46,6 +46,8 @@ cd luanti/android
 echo 'sdk.dir=/home/<YOUR USER>/android-sdk' >local.properties
 ```
 
+(On Windows, running `sdkmanager --sdk_root="<path to sdk>" "platform-tools"` might be enough)
+
 ### Building
 
 Optional: First figure out the ABI of the device you wish to build for
@@ -53,7 +55,13 @@ and disable all other ABIs to significantly reduce build times.
 (See [here](/improving-build-times/#android-disabling-unused-abis) for details.)
 
 Luanti uses a [Gradle Wrapper](https://docs.gradle.org/current/userguide/gradle_wrapper.html),
-which makes building Luanti for Android very easy: You just run
+which makes building Luanti for Android very easy: You just run.
+
+On Windows, the regular `gradle` tool works as well, so long as you install the additional Unix dependency [gettext](https://www.gnu.org/software/gettext/). Both of these are verified to work when installed by [Scoop](https://scoop.sh).
+
+
+
+ 
 
 ```sh
 cd luanti/android

--- a/content/compiling/android.md
+++ b/content/compiling/android.md
@@ -46,7 +46,7 @@ cd luanti/android
 echo 'sdk.dir=/home/<YOUR USER>/android-sdk' >local.properties
 ```
 
-(On Windows, running `sdkmanager --sdk_root="<path to sdk>" "platform-tools"` might be enough)
+_(On Windows, if the above doesn't work, try running the command `sdkmanager --sdk_root="<path to the folder you want to install SDK tools to>" "platform-tools"`. You will likely need to add this path to your [PATH environment variable](https://www.howtogeek.com/118594/how-to-edit-your-system-path-for-easy-command-line-access/), so PowerShell can recognize the installed components.)_
 
 ### Building
 
@@ -55,18 +55,15 @@ and disable all other ABIs to significantly reduce build times.
 (See [here](/improving-build-times/#android-disabling-unused-abis) for details.)
 
 Luanti uses a [Gradle Wrapper](https://docs.gradle.org/current/userguide/gradle_wrapper.html),
-which makes building Luanti for Android very easy: You just run.
-
-On Windows, the regular `gradle` tool works as well, so long as you install the additional Unix dependency [gettext](https://www.gnu.org/software/gettext/). Both of these are verified to work when installed by [Scoop](https://scoop.sh).
-
-
-
- 
+which makes building Luanti for Android very easy: You just run
 
 ```sh
 cd luanti/android
 ./gradlew app:assembleDebug
 ```
+
+_(If you're compiling on Windows, you can use the `gradle` command, so long as you install the additional Unix dependency [gettext](https://www.gnu.org/software/gettext/). Both of these are verified to work when installed by [Scoop](https://scoop.sh).)_
+
 
 This will produce a number of debug builds in the form of `.apk` files (depending on the enabled ABIs)
 in `android/app/build/outputs`:


### PR DESCRIPTION
Add information about things that were required for compiling for Android on Windows, from personal experience. 

I worded it as accurately to my knowledge as I can, as e.g. I don't know if the build guide's command for verifying the SDK licenses works or is necessary on Windows, but I know what I did to get it up and running, so as long as that information is on that page somewhere it can help others not get stuck on this stage of development.